### PR TITLE
Makes the accordion work correctly

### DIFF
--- a/cove/input/templates/datainput/input.html
+++ b/cove/input/templates/datainput/input.html
@@ -6,9 +6,9 @@
 
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="headingOne">
+    <div class="panel-heading" role="tab" id="headingOne" data-toggle="collapse" data-parent="#accordion" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
       <h4 class="panel-title">
-        <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+        <a class="accordion-toggle">
           <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>{% trans "Upload" %}
         </a>
       </h4>
@@ -27,14 +27,14 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="headingTwo">
+    <div class="panel-heading" role="tab" id="headingTwo" data-toggle="collapse" data-parent="#accordion" data-target="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo">
       <h4 class="panel-title">
-        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+        <a class="accordion-toggle">
           <span class="glyphicon glyphicon-link" aria-hidden="true"></span>{% trans "Link" %}
         </a>
       </h4>
     </div>
-    <div id="collapseTwo" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingTwo">
+    <div id="collapseTwo" class="panel-collapse show-open-if-noscript" role="tabpanel" aria-labelledby="headingTwo">
       <div class="panel-body">
         <form method="POST" action=".">{% csrf_token %}
             {% bootstrap_form forms.url_form %}
@@ -48,14 +48,14 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="headingThree">
+    <div class="panel-heading" role="tab" id="headingThree" data-toggle="collapse" data-parent="#accordion" data-target="#collapseThree" aria-expanded="true" aria-controls="collapseThree">
       <h4 class="panel-title">
-        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+        <a class="accordion-toggle">
           <span class="glyphicon glyphicon-paste" aria-hidden="true"></span>{% trans "Paste" %}
         </a>
       </h4>
     </div>
-    <div id="collapseThree" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingThree">
+    <div id="collapseThree" class="panel-collapse show-open-if-noscript" role="tabpanel" aria-labelledby="headingThree">
       <div class="panel-body">
         <form method="POST" action=".">{% csrf_token %}
             {% bootstrap_form forms.text_form %}
@@ -77,11 +77,9 @@
 
 {% block extrafooterscript %}
  <script>
-  $('#collapseThree').collapse({
-  hide: true
-  })
-  $('#collapseTwo').collapse({
-  hide: true
-  })
+   //If javascript is off all pannels show.
+   //We use this to collapse pannels 2 and 3 if javascript is on.
+  $("#collapseTwo").attr('class', 'panel-collapse collapse');
+  $("#collapseThree").attr('class', 'panel-collapse collapse');
 </script>
 {% endblock %}

--- a/cove/static/dataexplore/css/style.css
+++ b/cove/static/dataexplore/css/style.css
@@ -11,8 +11,16 @@ h1.application-name {
   margin: 10px 0;
 }
 
+#accordion .panel-heading {
+    cursor: pointer;
+}
+
+.panel-title a {
+  text-decoration:none;
+}
+
 .panel-title .glyphicon {
-padding-right:15px;
+  padding-right:15px;
 }
 
 #footer {
@@ -20,3 +28,7 @@ padding-right:15px;
   margin: 20px 0 40px;
   border-top: 1px solid #eee;
 } 
+
+show-open-if-noscript {
+display:block;
+}

--- a/cove/templates/explore.html
+++ b/cove/templates/explore.html
@@ -7,7 +7,12 @@
 
 <!--Download Converted Files-->
 <div class="panel panel-success">
-  <div class="panel-heading"><span class="glyphicon glyphicon-download" aria-hidden="true"></span>{% trans 'Download Files' %}</div>
+  <div class="panel-heading">
+    <h4 class="panel-title">
+      <span class="glyphicon glyphicon-download" aria-hidden="true"></span>{% trans 'Download Files' %}
+    </h4>
+  </div>
+      
   <div class="panel-body">
     {% if conversion == 'flatten' %}
       <ul>
@@ -27,7 +32,9 @@
 <div class="row">
   <div class="col-md-2">
     <div class="panel panel-default">
-      <div class="panel-heading">{% trans 'Number of Releases' %}</div>
+      <div class="panel-heading">
+        <h4 class="panel-title">{% trans 'Number of Releases' %}</h4>
+      </div>
       <div class="panel-body">
         {{releases_aggregates.count}}
       </div>


### PR DESCRIPTION
We load the page with everything extended. We then collapse boxes 2 and 3 if javascript is present.
The boxes act like the bootstrap example now.
Also makes minor changes to explore.html to align style with other pages

Also makes the full bars clickable to expand/collapse