### PR TITLE
[#30] Adds a list of unique ocids to the explore page

### DIFF
--- a/cove/templates/explore.html
+++ b/cove/templates/explore.html
@@ -43,7 +43,7 @@
       </div>
     </div>
   </div>
-   <div class="col-md-3">
+  <div class="col-md-3">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h4 class="panel-title">
@@ -56,6 +56,20 @@
         <li>{{ocid}}</li>
         {% endfor %}
         </ul>
+      </div>
+    </div>
+  </div>
+    <div class="col-md-3">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          {% trans "Release Dates" %}
+        </h4>
+      </div>
+      <div class="panel-body">
+        {% trans "Earliest:" %} {{releases_aggregates.earliest_release_date}}
+        <br>
+        {% trans "Latest:" %} {{releases_aggregates.latest_release_date}}
       </div>
     </div>
   </div>

--- a/cove/templates/explore.html
+++ b/cove/templates/explore.html
@@ -33,13 +33,29 @@
 
 <!-- Count of Releases -->
 <div class="row">
-  <div class="col-md-2">
+  <div class="col-md-3">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h4 class="panel-title">{% trans 'Number of Releases' %}</h4>
       </div>
       <div class="panel-body">
         {{releases_aggregates.count}}
+      </div>
+    </div>
+  </div>
+   <div class="col-md-3">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          {% blocktrans with number_of_ocids=releases_aggregates.unique_ocids|length %}Unique OCIDs ({{number_of_ocids}}){% endblocktrans %}
+        </h4>
+      </div>
+      <div class="panel-body">
+        <ul>
+        {% for ocid in releases_aggregates.unique_ocids %}
+        <li>{{ocid}}</li>
+        {% endfor %}
+        </ul>
       </div>
     </div>
   </div>

--- a/cove/tests.py
+++ b/cove/tests.py
@@ -9,15 +9,21 @@ from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 def test_get_releases_aggregates():
     assert v.get_releases_aggregates({}) == {
         'count': 0,
-        'unique_ocids': []
+        'unique_ocids': [],
+        'earliest_release_date': None,
+        'latest_release_date': None
     }
     assert v.get_releases_aggregates({'releases': []}) == {
         'count': 0,
-        'unique_ocids': set([])
+        'unique_ocids': set([]),
+        'earliest_release_date': None,
+        'latest_release_date': None
     }
     assert v.get_releases_aggregates({'releases': [{}, {}, {}]}) == {
         'count': 3,
-        'unique_ocids': set([])
+        'unique_ocids': set([]),
+        'earliest_release_date': None,
+        'latest_release_date': None
     }
 
 

--- a/cove/tests.py
+++ b/cove/tests.py
@@ -8,13 +8,16 @@ from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 
 def test_get_releases_aggregates():
     assert v.get_releases_aggregates({}) == {
-        'count': 0
+        'count': 0,
+        'unique_ocids': []
     }
     assert v.get_releases_aggregates({'releases': []}) == {
-        'count': 0
+        'count': 0,
+        'unique_ocids': set([])
     }
     assert v.get_releases_aggregates({'releases': [{}, {}, {}]}) == {
-        'count': 3
+        'count': 3,
+        'unique_ocids': set([])
     }
 
 

--- a/cove/views.py
+++ b/cove/views.py
@@ -9,10 +9,23 @@ import flattentool
 
 
 def get_releases_aggregates(json_data):
+    # Unique ocids
+    ocids = []
+    if 'releases' in json_data:
+        for release in json_data['releases']:
+            ocids.append(release['ocid']) if 'ocid' in release else 0
+        unique_ocids = set(ocids)
+    else:
+        unique_ocids = ocids
+    
+    # Number of releases
+    count = len(json_data['releases']) if 'releases' in json_data else 0
+    
     return {
-        'count': len(json_data['releases']) if 'releases' in json_data else 0
+        'count': count,
+        'unique_ocids': unique_ocids
     }
-
+    
 
 class UnrecognisedFileType(Exception):
     pass

--- a/cove/views.py
+++ b/cove/views.py
@@ -9,21 +9,29 @@ import flattentool
 
 
 def get_releases_aggregates(json_data):
-    # Unique ocids
+    # Unique ocids & Release dates
     ocids = []
+    unique_ocids = []
+    release_dates = []
+    earliest_release_date = None
+    latest_release_date = None
     if 'releases' in json_data:
         for release in json_data['releases']:
             ocids.append(release['ocid']) if 'ocid' in release else 0
+            release_dates.append(release['date']) if 'date' in release else 0
         unique_ocids = set(ocids)
-    else:
-        unique_ocids = ocids
-    
+        if release_dates:
+            earliest_release_date = min(release_dates)
+            latest_release_date = max(release_dates)
+
     # Number of releases
     count = len(json_data['releases']) if 'releases' in json_data else 0
     
     return {
         'count': count,
-        'unique_ocids': unique_ocids
+        'unique_ocids': unique_ocids,
+        'earliest_release_date': earliest_release_date,
+        'latest_release_date': latest_release_date
     }
     
 


### PR DESCRIPTION
I'm not sure if any of this is how you would want it, so please review carefully!

Alters the view to create a list of unique ocids found in the
releases.
Fixes up tests, and alters the template