### PR TITLE
360Giving is always 360Giving

### DIFF
--- a/cove/settings.py
+++ b/cove/settings.py
@@ -43,7 +43,7 @@ COVE_CONFIG_BY_NAMESPACE = {
     },
     'application_name': {
         'cove-ocds': _('Open Contracting Data Tool'),
-        'cove-360': _('360 Giving Data Tool'),
+        'cove-360': _('360Giving Data Tool'),
         'default': _('Cove'),
     },
     'schema_url': {  # Schema url for the package schema (does not yet exist for 360)

--- a/cove/templates/base_360.html
+++ b/cove/templates/base_360.html
@@ -3,7 +3,7 @@
 
 {% block link %}
 <li><a href="http://threesixtygiving.org/">{% trans "Three Sixty Degree Giving" %}</a></li>
-<li><a href="http://docs.threesixtygiving.org/">{% trans "360 Giving Data Standard" %}</a></li>
+<li><a href="http://docs.threesixtygiving.org/">{% trans "360Giving Data Standard" %}</a></li>
 {% endblock %}
 
 {% block howToUse %}
@@ -11,18 +11,18 @@
   <h2><small>{% blocktrans %}How to use the {{ application_name }}{% endblocktrans %}</small></h2>
   {% comment %}Translators: Paragraph that describes the application{% endcomment %}
   <p>{% blocktrans %}
-  Upload, paste or provide a link to data in the 360 Giving Data Standard format, and this application will convert between JSON, Excel and CSV formats, allowing you to download the original file, and the converted versions.{% endblocktrans %}</p>
+  Upload, paste or provide a link to data in the 360Giving Data Standard format, and this application will convert between JSON, Excel and CSV formats, allowing you to download the original file, and the converted versions.{% endblocktrans %}</p>
   
   <p>{% blocktrans %}You will also be able to inspect key information from the data that the application is able to find, so that you can check the data.{% endblocktrans %}</p>
   
   <h3><small>{% blocktrans %}Formats{% endblocktrans %}</small></h3>
   <p>{% blocktrans %}
-  The application accepts data in some of the formats given in the <a href="http://docs.threesixtygiving.org/publish/">360 Giving Data Standard publishing guidence</a> under <a href="http://docs.threesixtygiving.org/publish/#toc1">Choose your template</a>.
+  The application accepts data in some of the formats given in the <a href="http://docs.threesixtygiving.org/publish/">360Giving Data Standard publishing guidence</a> under <a href="http://docs.threesixtygiving.org/publish/#toc1">Choose your template</a>.
   <br>Acceptable files are: {% endblocktrans %}</p>
   <ul>
     <li>{% blocktrans %}Summary Spreadsheet - <a href="http://docs.threesixtygiving.org/assets/standard/schema/summary-table/360-giving-schema-titles.xlsx">Excel</a>{% endblocktrans %}</li>
     <!--<li>{% blocktrans %}Summary Spreadsheet - <a href="http://docs.threesixtygiving.org/assets/standard/schema/summary-table/360-giving-schema-titles.csv/Activity.csv">CSV</a>{% endblocktrans %}</li>-->
-    <li>{% blocktrans %}JSON built to the <a href="http://docs.threesixtygiving.org/docs/#json-schema">360 Giving Data Standard JSON schema</a>{% endblocktrans %}</li>
+    <li>{% blocktrans %}JSON built to the <a href="http://docs.threesixtygiving.org/docs/#json-schema">360Giving Data Standard JSON schema</a>{% endblocktrans %}</li>
     <li>{% blocktrans %}Multi-table data package - <a href="http://docs.threesixtygiving.org/assets/standard/schema/multi-table/360-giving-schema-fields.xlsx">Excel</a>{% endblocktrans %}</li>
   </ul>
 </div>

--- a/cove/templates/multi_index.html
+++ b/cove/templates/multi_index.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<h2><a href="{% url 'cove-360:index' %}">{% trans '360 Giving Data Tool' %}</a></h2>
+<h2><a href="{% url 'cove-360:index' %}">{% trans '360Giving Data Tool' %}</a></h2>
 <h2><a href="{% url 'cove-ocds:index' %}">{% trans 'Open Contracting Data Tool' %}</a></h2>
 
 {% endblock %}

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -28,11 +28,12 @@ def test_index_page_ocds(server_url, browser):
     
 def test_index_page_360(server_url, browser):
     browser.get(server_url + '/360/')
-    assert '360 Giving Data Tool' in browser.find_element_by_tag_name('body').text
-    assert 'How to use the 360 Giving Data Tool' in browser.find_element_by_tag_name('body').text
+    assert '360Giving Data Tool' in browser.find_element_by_tag_name('body').text
+    assert 'How to use the 360Giving Data Tool' in browser.find_element_by_tag_name('body').text
     assert 'Summary Spreadsheet - Excel' in browser.find_element_by_tag_name('body').text
-    assert 'JSON built to the 360 Giving Data Standard JSON schema' in browser.find_element_by_tag_name('body').text
+    assert 'JSON built to the 360Giving Data Standard JSON schema' in browser.find_element_by_tag_name('body').text
     assert 'Multi-table data package - Excel' in browser.find_element_by_tag_name('body').text
+    assert '360 Giving' not in browser.find_element_by_tag_name('body').text
 
 
 @pytest.mark.parametrize('prefix', ['/ocds/', '/360/'])
@@ -43,6 +44,7 @@ def test_common_index_elements(server_url, browser, prefix):
     assert 'Terms & Conditions' in browser.find_element_by_tag_name('body').text
     assert 'Open Data Services' in browser.find_element_by_tag_name('body').text
     assert 'Open Data Services Co-operative' not in browser.find_element_by_tag_name('body').text
+    assert '360 Giving' not in browser.find_element_by_tag_name('body').text
 
 
 @pytest.mark.parametrize('prefix', ['/ocds/', '/360/'])
@@ -50,6 +52,7 @@ def test_terms_page(server_url, browser, prefix):
     browser.get(server_url + prefix + 'terms/')
     assert 'Open Data Services Co-operative Limited' in browser.find_element_by_tag_name('body').text
     assert 'Open Data Services Limited' not in browser.find_element_by_tag_name('body').text
+    assert '360 Giving' not in browser.find_element_by_tag_name('body').text
     
 
 @pytest.mark.parametrize('prefix', ['/ocds/', '/360/'])
@@ -114,7 +117,8 @@ def test_URL_input(server_url, browser, httpserver, source_filename, prefix, exp
         # # Look for Release Table
         # assert 'Release Table' in browser.find_element_by_tag_name('body').text
     elif prefix == '/360/':
-        assert '360 Giving Data Tool' in browser.find_element_by_tag_name('body').text
+        assert '360Giving Data Tool' in browser.find_element_by_tag_name('body').text
+        assert '360 Giving' not in browser.find_element_by_tag_name('body').text
 
     if source_filename.endswith('.xlsx'):
         assert '(.xlsx) (Original)' in body_text
@@ -133,3 +137,4 @@ def test_URL_invalid_dataset_request(server_url, browser, prefix):
     # Test for a dataset that does not exist in the dataset. Not sure how we specify a UUID that will never be used again tho!
     browser.get(server_url + prefix + 'data/be0c2fd7-108b-4d78-bae2-5a8a096a8273')
     assert "We don't seem to be able to find the data you requested." in browser.find_element_by_tag_name('body').text
+    assert '360 Giving' not in browser.find_element_by_tag_name('body').text


### PR DESCRIPTION
We have been saying 360 Giving with a space.
This removes it and adds tests to make sure 360 Giving is not found