### PR TITLE
[#82][#83] Fixes up links from cove to the new 360 site

### DIFF
--- a/cove/settings.py
+++ b/cove/settings.py
@@ -44,7 +44,7 @@ COVE_CONFIG_BY_NAMESPACE = {
     'application_name': {
         'cove-ocds': _('Open Contracting Data Tool'),
         'cove-360': _('360Giving Data Tool'),
-        'default': _('Cove'),
+        'default': _('CoVE'),
     },
     'application_strapline': {
         'cove-ocds': _('Convert, Validate, Explore Open Contracting Data'),

--- a/cove/templates/base_360.html
+++ b/cove/templates/base_360.html
@@ -2,8 +2,8 @@
 {% load i18n %}
 
 {% block link %}
-<li><a href="http://threesixtygiving.org/">{% trans "Three Sixty Degree Giving" %}</a></li>
-<li><a href="http://docs.threesixtygiving.org/">{% trans "360Giving Data Standard" %}</a></li>
+<li><a href="http://www.threesixtygiving.org/">{% trans "360Giving" %}</a></li>
+<li><a href="http://www.threesixtygiving.org/standard/">{% trans "360Giving Data Standard" %}</a></li>
 {% endblock %}
 
 {% block howToUse %}
@@ -17,13 +17,12 @@
   
   <h3><small>{% blocktrans %}Formats{% endblocktrans %}</small></h3>
   <p>{% blocktrans %}
-  The application accepts data in some of the formats given in the <a href="http://docs.threesixtygiving.org/publish/">360Giving Data Standard publishing guidence</a> under <a href="http://docs.threesixtygiving.org/publish/#toc1">Choose your template</a>.
+  The application accepts data in some of the formats given in the <a href="http://www.threesixtygiving.org/standard/">360Giving Data Standard guidence</a>.
   <br>Acceptable files are: {% endblocktrans %}</p>
   <ul>
-    <li>{% blocktrans %}Summary Spreadsheet - <a href="http://docs.threesixtygiving.org/assets/standard/schema/summary-table/360-giving-schema-titles.xlsx">Excel</a>{% endblocktrans %}</li>
-    <!--<li>{% blocktrans %}Summary Spreadsheet - <a href="http://docs.threesixtygiving.org/assets/standard/schema/summary-table/360-giving-schema-titles.csv/Activity.csv">CSV</a>{% endblocktrans %}</li>-->
-    <li>{% blocktrans %}JSON built to the <a href="http://docs.threesixtygiving.org/docs/#json-schema">360Giving Data Standard JSON schema</a>{% endblocktrans %}</li>
-    <li>{% blocktrans %}Multi-table data package - <a href="http://docs.threesixtygiving.org/assets/standard/schema/multi-table/360-giving-schema-fields.xlsx">Excel</a>{% endblocktrans %}</li>
+    <li>{% blocktrans %}Summary Spreadsheet - <a href="https://github.com/ThreeSixtyGiving/standard/raw/master/schema/summary-table/360-giving-schema-titles.xlsx">Excel</a>, <a href="https://github.com/ThreeSixtyGiving/standard/raw/master/schema/summary-table/360-giving-schema-titles.csv/grants.csv">CSV</a>{% endblocktrans %}</li>
+    <li>{% blocktrans %}JSON built to the <a href="http://www.threesixtygiving.org/standard/reference/#toc-json-schema">360Giving Data Standard JSON schema</a>{% endblocktrans %}</li>
+    <li>{% blocktrans %}<a href="https://github.com/ThreeSixtyGiving/standard/raw/master/schema/multi-table/360-giving-schema-fields.xlsx">Multi-table data package - Excel</a>{% endblocktrans %}</li>
   </ul>
 </div>
 {% endblock %}

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -18,7 +18,7 @@ def server_url(request, live_server):
         return os.environ['CUSTOM_SERVER_URL']
     else:
         return live_server.url
-
+    
 
 def test_index_page_banner(server_url, browser):
     browser.get(server_url)
@@ -31,6 +31,34 @@ def test_index_page(server_url, browser):
     assert '360Giving Data Tool' in browser.find_element_by_tag_name('body').text
     assert 'Open Contracting Data Tool' in browser.find_element_by_tag_name('body').text
     assert 'Creating and using Open Data is made easier when there are good tools to help.' in browser.find_element_by_tag_name('body').text
+
+
+@pytest.mark.parametrize(('link_text', 'expected_text', 'css_selector', 'url'), [
+    ('Open Contracting', 'What is Open Contracting?', 'div#page-what h1', 'http://www.open-contracting.org/'),
+    ('Open Contracting Data Standard', 'OPEN CONTRACTING DATA STANDARD (OCDS) PROJECT SITE', 'h1.site-title', 'http://standard.open-contracting.org/'),
+    ])
+def test_footer_ocds(server_url, browser, link_text, expected_text, css_selector, url):
+    browser.get(server_url + '/ocds/')
+    link = browser.find_element_by_link_text(link_text)
+    href = link.get_attribute("href")
+    assert url in href
+    link.click()
+    time.sleep(0.5)
+    assert expected_text in browser.find_element_by_css_selector(css_selector).text
+
+
+@pytest.mark.parametrize(('link_text', 'expected_text', 'css_selector', 'url'), [
+    ('360Giving', 'We believe that with better information, grantmakers can be more effective and strategic decision-makers.', 'body.home', 'http://www.threesixtygiving.org/'),
+    ('360Giving Data Standard', 'Standard', 'h1.entry-title', 'http://www.threesixtygiving.org/standard/'),
+    ])
+def test_footer_360(server_url, browser, link_text, expected_text, css_selector, url):
+    browser.get(server_url + '/360/')
+    link = browser.find_element_by_link_text(link_text)
+    href = link.get_attribute("href")
+    assert url in href
+    link.click()
+    time.sleep(0.5)
+    assert expected_text in browser.find_element_by_css_selector(css_selector).text
 
 
 def test_index_page_ocds(server_url, browser):
@@ -47,6 +75,19 @@ def test_index_page_360(server_url, browser):
     assert 'JSON built to the 360Giving Data Standard JSON schema' in browser.find_element_by_tag_name('body').text
     assert 'Multi-table data package - Excel' in browser.find_element_by_tag_name('body').text
     assert '360 Giving' not in browser.find_element_by_tag_name('body').text
+  
+  
+@pytest.mark.parametrize(('link_text', 'url'), [
+    ('360Giving Data Standard guidence', 'http://www.threesixtygiving.org/standard/'),
+    ('Excel', 'https://github.com/ThreeSixtyGiving/standard/raw/master/schema/summary-table/360-giving-schema-titles.xlsx'),
+    ('CSV', 'https://github.com/ThreeSixtyGiving/standard/raw/master/schema/summary-table/360-giving-schema-titles.csv/grants.csv'),
+    ('360Giving Data Standard JSON schema', 'http://www.threesixtygiving.org/standard/reference/#toc-json-schema'),
+    ('Multi-table data package - Excel', 'https://github.com/ThreeSixtyGiving/standard/raw/master/schema/multi-table/360-giving-schema-fields.xlsx')
+    ])
+def test_index_page_360_links(server_url, browser, link_text, url):
+    link = browser.find_element_by_link_text(link_text)
+    href = link.get_attribute("href")
+    assert url in href
 
 
 @pytest.mark.parametrize('prefix', ['/ocds/', '/360/'])

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-18 10:03+0000\n"
+"POT-Creation-Date: 2015-08-10 12:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: cove/input/templates/datainput/input.html:12
+#: cove/input/templates/datainput/input.html:12 cove/templates/stats.html:10
 msgid "Upload"
 msgstr "Subir"
 
@@ -28,11 +28,12 @@ msgstr "Subir"
 msgid "Submit"
 msgstr "Presentar"
 
-#: cove/input/templates/datainput/input.html:33
+#: cove/input/templates/datainput/input.html:33 cove/templates/stats.html:11
 msgid "Link"
 msgstr "Enlace"
 
 #: cove/input/templates/datainput/input.html:54 cove/input/views.py:28
+#: cove/templates/stats.html:12
 msgid "Paste"
 msgstr "Pasta"
 
@@ -44,24 +45,36 @@ msgstr "Cargar un archivo"
 msgid "Supply a URL"
 msgstr "Proporcione una dirección URL"
 
-#: cove/settings.py:45 cove/templates/multi_index.html:8
+#: cove/settings.py:45 cove/templates/multi_index.html:28
 msgid "Open Contracting Data Tool"
 msgstr ""
 
-#: cove/settings.py:46
-msgid "360 Giving Data Tool"
+#: cove/settings.py:46 cove/templates/multi_index.html:16
+msgid "360Giving Data Tool"
 msgstr ""
 
 #: cove/settings.py:47
-msgid "Cove"
+msgid "CoVE"
+msgstr ""
+
+#: cove/settings.py:50
+msgid "Convert, Validate, Explore Open Contracting Data"
+msgstr ""
+
+#: cove/settings.py:51
+msgid "Convert, Validate, Explore 360Giving Data"
+msgstr ""
+
+#: cove/settings.py:52
+msgid "Convert, Validate, Explore"
 msgstr ""
 
 #: cove/templates/base_360.html:5
-msgid "Three Sixty Degree Giving"
+msgid "360Giving"
 msgstr ""
 
-#: cove/templates/base_360.html:6
-msgid "360 Giving Data Standard"
+#: cove/templates/base_360.html:6 cove/templates/multi_index.html:14
+msgid "360Giving Data Standard"
 msgstr ""
 
 #: cove/templates/base_360.html:11 cove/templates/base_ocds.html:11
@@ -73,7 +86,7 @@ msgstr ""
 #: cove/templates/base_360.html:13
 msgid ""
 "\n"
-"  Upload, paste or provide a link to data in the 360 Giving Data Standard "
+"  Upload, paste or provide a link to data in the 360Giving Data Standard "
 "format, and this application will convert between JSON, Excel and CSV "
 "formats, allowing you to download the original file, and the converted "
 "versions."
@@ -93,79 +106,74 @@ msgstr ""
 msgid ""
 "\n"
 "  The application accepts data in some of the formats given in the <a href="
-"\"http://docs.threesixtygiving.org/publish/\">360 Giving Data Standard "
-"publishing guidence</a> under <a href=\"http://docs.threesixtygiving.org/"
-"publish/#toc1\">Choose your template</a>.\n"
+"\"http://www.threesixtygiving.org/standard/\">360Giving Data Standard "
+"guidence</a>.\n"
 "  <br>Acceptable files are: "
 msgstr ""
 
 #: cove/templates/base_360.html:23
 msgid ""
-"Summary Spreadsheet - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/summary-table/360-giving-schema-titles.xlsx\">Excel</a>"
+"Summary Spreadsheet - <a href=\"https://github.com/ThreeSixtyGiving/standard/"
+"raw/master/schema/summary-table/360-giving-schema-titles.xlsx\">Excel</a>, "
+"<a href=\"https://github.com/ThreeSixtyGiving/standard/raw/master/schema/"
+"summary-table/360-giving-schema-titles.csv/grants.csv\">CSV</a>"
 msgstr ""
 
 #: cove/templates/base_360.html:24
 msgid ""
-"Summary Spreadsheet - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/summary-table/360-giving-schema-titles.csv/Activity.csv"
-"\">CSV</a>"
+"JSON built to the <a href=\"http://www.threesixtygiving.org/standard/"
+"reference/#toc-json-schema\">360Giving Data Standard JSON schema</a>"
 msgstr ""
 
 #: cove/templates/base_360.html:25
 msgid ""
-"JSON built to the <a href=\"http://docs.threesixtygiving.org/docs/#json-"
-"schema\">360 Giving Data Standard JSON schema</a>"
-msgstr ""
-
-#: cove/templates/base_360.html:26
-msgid ""
-"Multi-table data package - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/multi-table/360-giving-schema-fields.xlsx\">Excel</a>"
+"<a href=\"https://github.com/ThreeSixtyGiving/standard/raw/master/schema/"
+"multi-table/360-giving-schema-fields.xlsx\">Multi-table data package - "
+"Excel</a>"
 msgstr ""
 
 #. Translators: Label of a button that triggers search
-#: cove/templates/base_generic.html:38
+#: cove/templates/base_generic.html:40
 msgid "Go"
 msgstr ""
 
-#: cove/templates/base_generic.html:57
+#: cove/templates/base_generic.html:59
 msgid "What happens to the data I provide to this site?"
 msgstr ""
 
-#: cove/templates/base_generic.html:58
+#: cove/templates/base_generic.html:60
 msgid ""
 "We retain the data you upload or paste to this site, on our server, for 7 "
 "days."
 msgstr ""
 
-#: cove/templates/base_generic.html:59
+#: cove/templates/base_generic.html:61
 msgid ""
 "If you supply a link, we fetch the data from that link and store it on our "
 "server for 7 days."
 msgstr ""
 
-#: cove/templates/base_generic.html:60
+#: cove/templates/base_generic.html:62
 msgid ""
 "We delete all data older than 7 days from our servers daily, retaining none "
 "of the original data."
 msgstr ""
 
-#: cove/templates/base_generic.html:61
+#: cove/templates/base_generic.html:63
 msgid ""
 "While the data is on our servers we may access that data to help us "
 "understand how people are using this application, what types of data are "
 "being supplied, what common errors exist and so on."
 msgstr ""
 
-#: cove/templates/base_generic.html:62
+#: cove/templates/base_generic.html:64
 msgid ""
 "We may also retain data in backups of our servers, which means on occassion, "
 "some data may be retained longer. We have no intention of using this data "
 "for anything other than server recovery in an emergency."
 msgstr ""
 
-#: cove/templates/base_generic.html:63
+#: cove/templates/base_generic.html:65
 msgid ""
 "We do retain some metadata about data supplied to this site. Details can be "
 "found in the code, but may include information about whether or not the file "
@@ -173,11 +181,11 @@ msgid ""
 "supplied and so on. "
 msgstr ""
 
-#: cove/templates/base_generic.html:65
+#: cove/templates/base_generic.html:67
 msgid "Why do you delete data after 7 days?"
 msgstr ""
 
-#: cove/templates/base_generic.html:66
+#: cove/templates/base_generic.html:68
 msgid ""
 "This is service to allow people to explore machine readable data. As such we "
 "see no need to store and gather everything people submit to the site "
@@ -186,17 +194,17 @@ msgid ""
 "to save people having to clean up after themselves."
 msgstr ""
 
-#: cove/templates/base_generic.html:67
+#: cove/templates/base_generic.html:69
 msgid ""
 "We believe that deleting supplied data after 7 days provides a level of "
 "privacy for the users of this service. "
 msgstr ""
 
-#: cove/templates/base_generic.html:73
+#: cove/templates/base_generic.html:75
 msgid "Why provide converted versions?"
 msgstr ""
 
-#: cove/templates/base_generic.html:74
+#: cove/templates/base_generic.html:76
 msgid ""
 "\n"
 "    The W3C <a href=\"http://www.w3.org/TR/dwbp/\">Data on the Web Best "
@@ -206,59 +214,59 @@ msgid ""
 "    "
 msgstr ""
 
-#: cove/templates/base_generic.html:86
+#: cove/templates/base_generic.html:88
 msgid "About"
 msgstr ""
 
-#: cove/templates/base_generic.html:88
+#: cove/templates/base_generic.html:90
 msgid "Built by"
 msgstr ""
 
-#: cove/templates/base_generic.html:88
-msgid "Open Data Services Co-operative"
+#: cove/templates/base_generic.html:90
+msgid "Open Data Services"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "The code for this site is available on"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "GitHub"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Cove - COnvert Validate & Explore"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Licence"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "AGPLv3"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Report/View issues"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Cove Issues"
 msgstr ""
 
-#: cove/templates/base_generic.html:93
+#: cove/templates/base_generic.html:95
 msgid "Terms &amp; Conditions"
 msgstr ""
 
 #. Translators: Provides information about the version of the code base that is being used
-#: cove/templates/base_generic.html:96
+#: cove/templates/base_generic.html:98
 #, python-format
 msgid ""
 "Running version <a href=\"https://github.com/OpenDataServices/cove/tree/"
 "%(version)s\">%(version)s</a>."
 msgstr ""
 
-#: cove/templates/base_generic.html:99
+#: cove/templates/base_generic.html:101
 #, fuzzy
 #| msgid "Link"
 msgid "Links"
@@ -268,7 +276,7 @@ msgstr "Enlace"
 msgid "Open Contracting"
 msgstr ""
 
-#: cove/templates/base_ocds.html:6
+#: cove/templates/base_ocds.html:6 cove/templates/multi_index.html:26
 msgid "Open Contracting Data Standard"
 msgstr ""
 
@@ -301,78 +309,144 @@ msgid "Excel Spreadsheet (.xlsx)"
 msgstr ""
 
 #: cove/templates/explore.html:8
+msgid "CSV Spreadsheet (.csv)"
+msgstr ""
+
+#: cove/templates/explore.html:9
 msgid "Excel Spreadsheet (.xlsx) with titles"
 msgstr ""
 
 #. Translators: JSON probably does not need a transalation: http://www.json.org/
-#: cove/templates/explore.html:10
+#: cove/templates/explore.html:11
 msgid "JSON"
 msgstr ""
 
-#: cove/templates/explore.html:16
+#: cove/templates/explore.html:17
 msgid "Download Files"
 msgstr "Bajar Archivos"
 
-#: cove/templates/explore.html:23 cove/templates/explore.html.py:24
-#: cove/templates/explore.html:25 cove/templates/explore.html.py:29
-#: cove/templates/explore.html:30
+#: cove/templates/explore.html:24 cove/templates/explore.html.py:25
+#: cove/templates/explore.html:26 cove/templates/explore.html.py:32
+#: cove/templates/explore.html:34 cove/templates/explore.html.py:37
 #, python-format
 msgid "%(file_format)s (%(status)s)"
 msgstr ""
 
-#: cove/templates/explore.html:43
+#: cove/templates/explore.html:50
 msgid "Validates against the schema?"
 msgstr ""
 
-#: cove/templates/explore.html:58
+#: cove/templates/explore.html:65
 #, fuzzy
 #| msgid "Number of Releases"
 msgid "Number of releases"
 msgstr "Número de Releases"
 
-#: cove/templates/explore.html:69
+#: cove/templates/explore.html:76
 #, python-format
 msgid "Unique OCIDs (%(number_of_ocids)s)"
 msgstr ""
 
-#: cove/templates/explore.html:85
+#: cove/templates/explore.html:92
 msgid "Release Dates"
 msgstr ""
 
-#: cove/templates/explore.html:89
+#: cove/templates/explore.html:96
 msgid "Earliest:"
 msgstr ""
 
-#: cove/templates/explore.html:91
+#: cove/templates/explore.html:98
 msgid "Latest:"
 msgstr ""
 
-#: cove/templates/explore.html:99
+#: cove/templates/explore.html:106
 msgid "Releases Table:"
 msgstr ""
 
-#: cove/templates/explore.html:123
+#: cove/templates/explore.html:136
 #, fuzzy
 #| msgid "Number of Releases"
 msgid "Number of grants"
 msgstr "Número de Releases"
 
-#: cove/templates/explore.html:135
+#: cove/templates/explore.html:148
+#, python-format
+msgid "Unique IDs (%(number_of_ids)s)"
+msgstr ""
+
+#: cove/templates/explore.html:164
+msgid "Grants Table:"
+msgstr ""
+
+#: cove/templates/explore.html:190
 msgid "Save or Share these results"
 msgstr ""
 
 #. Translators: Paragraph that describes the application
-#: cove/templates/explore.html:137
+#: cove/templates/explore.html:192
 msgid ""
 "These results will be available for 7 days from the day the data was first "
 "uploaded. You can revisit these results until then."
 msgstr ""
 
-#: cove/templates/explore.html:139
+#: cove/templates/explore.html:194
 msgid ""
 "After 7 days all uploaded data is deleted from our servers, and the results "
 "will no longer be available. Anyone using the link to this page after that "
 "will be show a message that tells them the file has been removed."
+msgstr ""
+
+#: cove/templates/multi_index.html:12
+msgid "360Giving Logo"
+msgstr ""
+
+#: cove/templates/multi_index.html:15
+msgid ""
+"360Giving provides support for grantmakers to publish their grants data "
+"openly, to understand their data, and to use the data to create online tools "
+"that make grant-making more effective."
+msgstr ""
+
+#: cove/templates/multi_index.html:24
+msgid "Open Contracting Logo"
+msgstr ""
+
+#: cove/templates/multi_index.html:27
+msgid ""
+"The Open Contracting Data Standard promotes the effective use of contracting "
+"data, helping users to “follow the money”, and it provides a clear template "
+"for governments wishing to disclose their data."
+msgstr ""
+
+#: cove/templates/multi_index.html:35
+msgid ""
+"Creating and using Open Data is made easier when there are good tools to "
+"help."
+msgstr ""
+
+#: cove/templates/multi_index.html:36
+msgid "CoVE exisits to help people:"
+msgstr ""
+
+#: cove/templates/multi_index.html:38
+msgid "Convert data between common formats (e.g. csv to json)"
+msgstr ""
+
+#: cove/templates/multi_index.html:39
+msgid "Validate data against rules"
+msgstr ""
+
+#: cove/templates/multi_index.html:40
+msgid "Explore data, that machines find easy, but humans find harder to read"
+msgstr ""
+
+#: cove/templates/stats.html:4
+msgid "Usage stats"
+msgstr ""
+
+#: cove/templates/stats.html:19
+#, python-format
+msgid "Last %(num_days)s days"
 msgstr ""
 
 #: cove/templates/terms.html:6
@@ -395,18 +469,20 @@ msgstr ""
 msgid ""
 "If you continue to browse and use this website, you are agreeing to comply "
 "with and be bound by the following terms and conditions of use, which "
-"together with our privacy policy govern Open Data Services Limited's "
-"relationship with you in relation to this website. If you disagree with any "
-"part of these terms and conditions, please do not use our website."
+"together with our privacy policy govern Open Data Services Co-operative "
+"Limited's relationship with you in relation to this website. If you disagree "
+"with any part of these terms and conditions, please do not use our website."
 msgstr ""
 
 #: cove/templates/terms.html:13
 msgid ""
-"The term 'Open Data Services Limited' or 'us' or 'we' refers to the owner of "
-"the website. Our company registration number is 09506232. There is more "
-"company information on the <a href=\"https://opencorporates.com/companies/"
-"gb/09506232\">Open Data Services Limited page at Open Corporates</a>. The "
-"term 'you' refers to the user or viewer of our website."
+"The term 'Open Data Services Co-operative Limited' or 'us' or 'we' refers to "
+"the owner of the website. Our company registration number is 09506232. Our "
+"registered address is 32 Church Road, Hove, East Sussex, England, BN3 2FN. "
+"There is more company information on the <a href=\"https://opencorporates."
+"com/companies/gb/09506232\">Open Data Services Co-operative Limited page at "
+"Open Corporates</a>. The term 'you' refers to the user or viewer of our "
+"website."
 msgstr ""
 
 #: cove/templates/terms.html:15
@@ -567,9 +643,10 @@ msgstr ""
 
 #: cove/templates/terms.html:73
 msgid ""
-"Open Data Services Limited keep server logs of traffic to, and activity on, "
-"our all of our servers. Primarily this is to help us keep our servers "
-"healthy and working by knowing how much activity is taking place on them."
+"Open Data Services Co-operative Limited keep server logs of traffic to, and "
+"activity on, our all of our servers. Primarily this is to help us keep our "
+"servers healthy and working by knowing how much activity is taking place on "
+"them."
 msgstr ""
 
 #: cove/templates/terms.html:75
@@ -593,25 +670,25 @@ msgstr ""
 
 #: cove/templates/terms.html:79
 msgid ""
-"This privacy policy sets out how Open Data Services Limited uses and "
-"protects any information that you give Open Data Services Limited when you "
-"use this website."
+"This privacy policy sets out how Open Data Services Co-operative Limited "
+"uses and protects any information that you give Open Data Services Co-"
+"operative Limited when you use this website."
 msgstr ""
 
 #: cove/templates/terms.html:81
 msgid ""
-"Open Data Services Limited is committed to ensuring that your privacy is "
-"protected. Should we ask you to provide certain information by which you can "
-"be identified when using this website, then you can be assured that it will "
-"only be used in accordance with this privacy statement."
+"Open Data Services Co-operative Limited is committed to ensuring that your "
+"privacy is protected. Should we ask you to provide certain information by "
+"which you can be identified when using this website, then you can be assured "
+"that it will only be used in accordance with this privacy statement."
 msgstr ""
 
 #: cove/templates/terms.html:83
 msgid ""
-"Open Data Services Limited may change this policy from time to time by "
-"updating this page. You should check this page from time to time to ensure "
-"that you are happy with any changes. This policy is effective from 1st April "
-"2015."
+"Open Data Services Co-operative Limited may change this policy from time to "
+"time by updating this page. You should check this page from time to time to "
+"ensure that you are happy with any changes. This policy is effective from "
+"1st April 2015."
 msgstr ""
 
 #: cove/templates/terms.html:85
@@ -635,16 +712,16 @@ msgstr ""
 #: cove/templates/terms.html:90
 msgid ""
 "\n"
-"  Open Data Services Limited does not make use of any of the data within the "
-"files for purposes other than to create reports for you about the data you "
-"have submitted."
+"  Open Data Services Co-operative Limited does not make use of any of the "
+"data within the files for purposes other than to create reports for you "
+"about the data you have submitted."
 msgstr ""
 
 #: cove/templates/terms.html:93
 msgid ""
-"Open Data Services Limited does create and store metadata about your use of "
-"the application, and about the files/data that you have uploaded in order to "
-"monitor how the application is being used."
+"Open Data Services Co-operative Limited does create and store metadata about "
+"your use of the application, and about the files/data that you have uploaded "
+"in order to monitor how the application is being used."
 msgstr ""
 
 #: cove/templates/terms.html:95
@@ -689,8 +766,10 @@ msgid ""
 "hold about you under the Data Protection Act 1998. A small fee will be "
 "payable. If you would like a copy of the information held on you please "
 "email the Data Protection Officer at company@opendataservices.coop. If you "
-"would like to write to us our contact details are available on the Open Data "
-"Services Limited page at Open Corporates."
+"would like to write to us our registered addresess is 32 Church Road, Hove, "
+"East Sussex, England, BN3 2FN. Further details are available on the <a href="
+"\"https://opencorporates.com/companies/gb/09506232\">Open Data Services Co-"
+"operative Limited page at Open Corporates</a>."
 msgstr ""
 
 #: cove/templates/terms.html:108
@@ -734,41 +813,42 @@ msgstr ""
 #: cove/templates/terms.html:117
 msgid ""
 "The information contained in this website is for general information "
-"purposes only. The information is provided by Open Data Services Limited and "
-"while we endeavour to keep the information up to date and correct, we make "
-"no representations or warranties of any kind, express or implied, about the "
-"completeness, accuracy, reliability, suitability or availability with "
-"respect to the website or the information, products, services, or related "
-"graphics contained on the website for any purpose. Any reliance you place on "
-"such information is therefore strictly at your own risk.\n"
+"purposes only. The information is provided by Open Data Services Co-"
+"operative Limited and while we endeavour to keep the information up to date "
+"and correct, we make no representations or warranties of any kind, express "
+"or implied, about the completeness, accuracy, reliability, suitability or "
+"availability with respect to the website or the information, products, "
+"services, or related graphics contained on the website for any purpose. Any "
+"reliance you place on such information is therefore strictly at your own "
+"risk.\n"
 "  In no event will we be liable for any loss or damage including without "
 "limitation, indirect or consequential loss or damage, or any loss or damage "
 "whatsoever arising from loss of data or profits arising out of, or in "
 "connection with, the use of this website.\n"
 "  Through this website you are able to link to other websites which are not "
-"under the control of Open Data Services Limited. We have no control over the "
-"nature, content and availability of those sites. The inclusion of any links "
-"does not necessarily imply a recommendation or endorse the views expressed "
-"within them.\n"
+"under the control of Open Data Services Co-operative Limited. We have no "
+"control over the nature, content and availability of those sites. The "
+"inclusion of any links does not necessarily imply a recommendation or "
+"endorse the views expressed within them.\n"
 "  Every effort is made to keep the website up and running smoothly. However, "
-"Open Data Services Limited takes no responsibility for, and will not be "
-"liable for, the website being temporarily unavailable due to technical "
-"issues beyond our control."
+"Open Data Services Co-operative Limited takes no responsibility for, and "
+"will not be liable for, the website being temporarily unavailable due to "
+"technical issues beyond our control."
 msgstr ""
 
-#: cove/views.py:101 cove/views.py:111
+#: cove/views.py:108 cove/views.py:118
 msgid "Sorry, the page you are looking for is not available"
 msgstr ""
 
-#: cove/views.py:103 cove/views.py:113
+#: cove/views.py:110 cove/views.py:120
 msgid "Go to Home page"
 msgstr ""
 
-#: cove/views.py:104
+#: cove/views.py:111
 msgid "We don't seem to be able to find the data you requested."
 msgstr ""
 
-#: cove/views.py:114
+#: cove/views.py:121
 msgid ""
 "The data you were hoping to explore no longer exists.\n"
 "\n"
@@ -776,24 +856,24 @@ msgid ""
 "after 7 days, and therefore the analysis of that data is no longer available."
 msgstr ""
 
-#: cove/views.py:121 cove/views.py:152
+#: cove/views.py:128 cove/views.py:159
 msgid "Sorry we can't process that data"
 msgstr ""
 
-#: cove/views.py:123 cove/views.py:154
+#: cove/views.py:130 cove/views.py:161
 msgid "Try Again"
 msgstr ""
 
-#: cove/views.py:124
+#: cove/views.py:131
 msgid ""
 "We did not recognise the file type.\n"
 "\n"
-"We can only process json, xls, xlsx and csv files.\n"
+"We can only process json, csv and xlsx files.\n"
 "\n"
 "Is this a bug? Contact us on code [at] opendataservices.coop"
 msgstr ""
 
-#: cove/views.py:155
+#: cove/views.py:162
 msgid ""
 "We think you tried to upload a JSON file, but it is not well formed JSON.\n"
 "\n"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-18 10:03+0000\n"
+"POT-Creation-Date: 2015-08-10 12:54+0000\n"
 "PO-Revision-Date: 2015-04-27 18:06-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.7.5\n"
 
-#: cove/input/templates/datainput/input.html:12
+#: cove/input/templates/datainput/input.html:12 cove/templates/stats.html:10
 #, fuzzy
 #| msgid "Upload a file"
 msgid "Upload"
@@ -30,11 +30,12 @@ msgstr "Télécharger un fichier"
 msgid "Submit"
 msgstr "Soumettre"
 
-#: cove/input/templates/datainput/input.html:33
+#: cove/input/templates/datainput/input.html:33 cove/templates/stats.html:11
 msgid "Link"
 msgstr ""
 
 #: cove/input/templates/datainput/input.html:54 cove/input/views.py:28
+#: cove/templates/stats.html:12
 msgid "Paste"
 msgstr ""
 
@@ -46,24 +47,36 @@ msgstr "Télécharger un fichier"
 msgid "Supply a URL"
 msgstr "Fournir une URL"
 
-#: cove/settings.py:45 cove/templates/multi_index.html:8
+#: cove/settings.py:45 cove/templates/multi_index.html:28
 msgid "Open Contracting Data Tool"
 msgstr ""
 
-#: cove/settings.py:46
-msgid "360 Giving Data Tool"
+#: cove/settings.py:46 cove/templates/multi_index.html:16
+msgid "360Giving Data Tool"
 msgstr ""
 
 #: cove/settings.py:47
-msgid "Cove"
+msgid "CoVE"
+msgstr ""
+
+#: cove/settings.py:50
+msgid "Convert, Validate, Explore Open Contracting Data"
+msgstr ""
+
+#: cove/settings.py:51
+msgid "Convert, Validate, Explore 360Giving Data"
+msgstr ""
+
+#: cove/settings.py:52
+msgid "Convert, Validate, Explore"
 msgstr ""
 
 #: cove/templates/base_360.html:5
-msgid "Three Sixty Degree Giving"
+msgid "360Giving"
 msgstr ""
 
-#: cove/templates/base_360.html:6
-msgid "360 Giving Data Standard"
+#: cove/templates/base_360.html:6 cove/templates/multi_index.html:14
+msgid "360Giving Data Standard"
 msgstr ""
 
 #: cove/templates/base_360.html:11 cove/templates/base_ocds.html:11
@@ -75,7 +88,7 @@ msgstr ""
 #: cove/templates/base_360.html:13
 msgid ""
 "\n"
-"  Upload, paste or provide a link to data in the 360 Giving Data Standard "
+"  Upload, paste or provide a link to data in the 360Giving Data Standard "
 "format, and this application will convert between JSON, Excel and CSV "
 "formats, allowing you to download the original file, and the converted "
 "versions."
@@ -95,79 +108,74 @@ msgstr ""
 msgid ""
 "\n"
 "  The application accepts data in some of the formats given in the <a href="
-"\"http://docs.threesixtygiving.org/publish/\">360 Giving Data Standard "
-"publishing guidence</a> under <a href=\"http://docs.threesixtygiving.org/"
-"publish/#toc1\">Choose your template</a>.\n"
+"\"http://www.threesixtygiving.org/standard/\">360Giving Data Standard "
+"guidence</a>.\n"
 "  <br>Acceptable files are: "
 msgstr ""
 
 #: cove/templates/base_360.html:23
 msgid ""
-"Summary Spreadsheet - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/summary-table/360-giving-schema-titles.xlsx\">Excel</a>"
+"Summary Spreadsheet - <a href=\"https://github.com/ThreeSixtyGiving/standard/"
+"raw/master/schema/summary-table/360-giving-schema-titles.xlsx\">Excel</a>, "
+"<a href=\"https://github.com/ThreeSixtyGiving/standard/raw/master/schema/"
+"summary-table/360-giving-schema-titles.csv/grants.csv\">CSV</a>"
 msgstr ""
 
 #: cove/templates/base_360.html:24
 msgid ""
-"Summary Spreadsheet - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/summary-table/360-giving-schema-titles.csv/Activity.csv"
-"\">CSV</a>"
+"JSON built to the <a href=\"http://www.threesixtygiving.org/standard/"
+"reference/#toc-json-schema\">360Giving Data Standard JSON schema</a>"
 msgstr ""
 
 #: cove/templates/base_360.html:25
 msgid ""
-"JSON built to the <a href=\"http://docs.threesixtygiving.org/docs/#json-"
-"schema\">360 Giving Data Standard JSON schema</a>"
-msgstr ""
-
-#: cove/templates/base_360.html:26
-msgid ""
-"Multi-table data package - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/multi-table/360-giving-schema-fields.xlsx\">Excel</a>"
+"<a href=\"https://github.com/ThreeSixtyGiving/standard/raw/master/schema/"
+"multi-table/360-giving-schema-fields.xlsx\">Multi-table data package - "
+"Excel</a>"
 msgstr ""
 
 #. Translators: Label of a button that triggers search
-#: cove/templates/base_generic.html:38
+#: cove/templates/base_generic.html:40
 msgid "Go"
 msgstr ""
 
-#: cove/templates/base_generic.html:57
+#: cove/templates/base_generic.html:59
 msgid "What happens to the data I provide to this site?"
 msgstr ""
 
-#: cove/templates/base_generic.html:58
+#: cove/templates/base_generic.html:60
 msgid ""
 "We retain the data you upload or paste to this site, on our server, for 7 "
 "days."
 msgstr ""
 
-#: cove/templates/base_generic.html:59
+#: cove/templates/base_generic.html:61
 msgid ""
 "If you supply a link, we fetch the data from that link and store it on our "
 "server for 7 days."
 msgstr ""
 
-#: cove/templates/base_generic.html:60
+#: cove/templates/base_generic.html:62
 msgid ""
 "We delete all data older than 7 days from our servers daily, retaining none "
 "of the original data."
 msgstr ""
 
-#: cove/templates/base_generic.html:61
+#: cove/templates/base_generic.html:63
 msgid ""
 "While the data is on our servers we may access that data to help us "
 "understand how people are using this application, what types of data are "
 "being supplied, what common errors exist and so on."
 msgstr ""
 
-#: cove/templates/base_generic.html:62
+#: cove/templates/base_generic.html:64
 msgid ""
 "We may also retain data in backups of our servers, which means on occassion, "
 "some data may be retained longer. We have no intention of using this data "
 "for anything other than server recovery in an emergency."
 msgstr ""
 
-#: cove/templates/base_generic.html:63
+#: cove/templates/base_generic.html:65
 msgid ""
 "We do retain some metadata about data supplied to this site. Details can be "
 "found in the code, but may include information about whether or not the file "
@@ -175,11 +183,11 @@ msgid ""
 "supplied and so on. "
 msgstr ""
 
-#: cove/templates/base_generic.html:65
+#: cove/templates/base_generic.html:67
 msgid "Why do you delete data after 7 days?"
 msgstr ""
 
-#: cove/templates/base_generic.html:66
+#: cove/templates/base_generic.html:68
 msgid ""
 "This is service to allow people to explore machine readable data. As such we "
 "see no need to store and gather everything people submit to the site "
@@ -188,17 +196,17 @@ msgid ""
 "to save people having to clean up after themselves."
 msgstr ""
 
-#: cove/templates/base_generic.html:67
+#: cove/templates/base_generic.html:69
 msgid ""
 "We believe that deleting supplied data after 7 days provides a level of "
 "privacy for the users of this service. "
 msgstr ""
 
-#: cove/templates/base_generic.html:73
+#: cove/templates/base_generic.html:75
 msgid "Why provide converted versions?"
 msgstr ""
 
-#: cove/templates/base_generic.html:74
+#: cove/templates/base_generic.html:76
 msgid ""
 "\n"
 "    The W3C <a href=\"http://www.w3.org/TR/dwbp/\">Data on the Web Best "
@@ -208,59 +216,59 @@ msgid ""
 "    "
 msgstr ""
 
-#: cove/templates/base_generic.html:86
+#: cove/templates/base_generic.html:88
 msgid "About"
 msgstr ""
 
-#: cove/templates/base_generic.html:88
+#: cove/templates/base_generic.html:90
 msgid "Built by"
 msgstr ""
 
-#: cove/templates/base_generic.html:88
-msgid "Open Data Services Co-operative"
+#: cove/templates/base_generic.html:90
+msgid "Open Data Services"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "The code for this site is available on"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "GitHub"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Cove - COnvert Validate & Explore"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Licence"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "AGPLv3"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Report/View issues"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Cove Issues"
 msgstr ""
 
-#: cove/templates/base_generic.html:93
+#: cove/templates/base_generic.html:95
 msgid "Terms &amp; Conditions"
 msgstr ""
 
 #. Translators: Provides information about the version of the code base that is being used
-#: cove/templates/base_generic.html:96
+#: cove/templates/base_generic.html:98
 #, python-format
 msgid ""
 "Running version <a href=\"https://github.com/OpenDataServices/cove/tree/"
 "%(version)s\">%(version)s</a>."
 msgstr ""
 
-#: cove/templates/base_generic.html:99
+#: cove/templates/base_generic.html:101
 msgid "Links"
 msgstr ""
 
@@ -268,7 +276,7 @@ msgstr ""
 msgid "Open Contracting"
 msgstr ""
 
-#: cove/templates/base_ocds.html:6
+#: cove/templates/base_ocds.html:6 cove/templates/multi_index.html:26
 msgid "Open Contracting Data Standard"
 msgstr ""
 
@@ -301,74 +309,140 @@ msgid "Excel Spreadsheet (.xlsx)"
 msgstr ""
 
 #: cove/templates/explore.html:8
+msgid "CSV Spreadsheet (.csv)"
+msgstr ""
+
+#: cove/templates/explore.html:9
 msgid "Excel Spreadsheet (.xlsx) with titles"
 msgstr ""
 
 #. Translators: JSON probably does not need a transalation: http://www.json.org/
-#: cove/templates/explore.html:10
+#: cove/templates/explore.html:11
 msgid "JSON"
 msgstr ""
 
-#: cove/templates/explore.html:16
+#: cove/templates/explore.html:17
 msgid "Download Files"
 msgstr ""
 
-#: cove/templates/explore.html:23 cove/templates/explore.html.py:24
-#: cove/templates/explore.html:25 cove/templates/explore.html.py:29
-#: cove/templates/explore.html:30
+#: cove/templates/explore.html:24 cove/templates/explore.html.py:25
+#: cove/templates/explore.html:26 cove/templates/explore.html.py:32
+#: cove/templates/explore.html:34 cove/templates/explore.html.py:37
 #, python-format
 msgid "%(file_format)s (%(status)s)"
 msgstr ""
 
-#: cove/templates/explore.html:43
+#: cove/templates/explore.html:50
 msgid "Validates against the schema?"
 msgstr ""
 
-#: cove/templates/explore.html:58
+#: cove/templates/explore.html:65
 msgid "Number of releases"
 msgstr ""
 
-#: cove/templates/explore.html:69
+#: cove/templates/explore.html:76
 #, python-format
 msgid "Unique OCIDs (%(number_of_ocids)s)"
 msgstr ""
 
-#: cove/templates/explore.html:85
+#: cove/templates/explore.html:92
 msgid "Release Dates"
 msgstr ""
 
-#: cove/templates/explore.html:89
+#: cove/templates/explore.html:96
 msgid "Earliest:"
 msgstr ""
 
-#: cove/templates/explore.html:91
+#: cove/templates/explore.html:98
 msgid "Latest:"
 msgstr ""
 
-#: cove/templates/explore.html:99
+#: cove/templates/explore.html:106
 msgid "Releases Table:"
 msgstr ""
 
-#: cove/templates/explore.html:123
+#: cove/templates/explore.html:136
 msgid "Number of grants"
 msgstr ""
 
-#: cove/templates/explore.html:135
+#: cove/templates/explore.html:148
+#, python-format
+msgid "Unique IDs (%(number_of_ids)s)"
+msgstr ""
+
+#: cove/templates/explore.html:164
+msgid "Grants Table:"
+msgstr ""
+
+#: cove/templates/explore.html:190
 msgid "Save or Share these results"
 msgstr ""
 
 #. Translators: Paragraph that describes the application
-#: cove/templates/explore.html:137
+#: cove/templates/explore.html:192
 msgid ""
 "These results will be available for 7 days from the day the data was first "
 "uploaded. You can revisit these results until then."
 msgstr ""
 
-#: cove/templates/explore.html:139
+#: cove/templates/explore.html:194
 msgid ""
 "After 7 days all uploaded data is deleted from our servers, and the results "
 "will no longer be available. Anyone using the link to this page after that "
 "will be show a message that tells them the file has been removed."
+msgstr ""
+
+#: cove/templates/multi_index.html:12
+msgid "360Giving Logo"
+msgstr ""
+
+#: cove/templates/multi_index.html:15
+msgid ""
+"360Giving provides support for grantmakers to publish their grants data "
+"openly, to understand their data, and to use the data to create online tools "
+"that make grant-making more effective."
+msgstr ""
+
+#: cove/templates/multi_index.html:24
+msgid "Open Contracting Logo"
+msgstr ""
+
+#: cove/templates/multi_index.html:27
+msgid ""
+"The Open Contracting Data Standard promotes the effective use of contracting "
+"data, helping users to “follow the money”, and it provides a clear template "
+"for governments wishing to disclose their data."
+msgstr ""
+
+#: cove/templates/multi_index.html:35
+msgid ""
+"Creating and using Open Data is made easier when there are good tools to "
+"help."
+msgstr ""
+
+#: cove/templates/multi_index.html:36
+msgid "CoVE exisits to help people:"
+msgstr ""
+
+#: cove/templates/multi_index.html:38
+msgid "Convert data between common formats (e.g. csv to json)"
+msgstr ""
+
+#: cove/templates/multi_index.html:39
+msgid "Validate data against rules"
+msgstr ""
+
+#: cove/templates/multi_index.html:40
+msgid "Explore data, that machines find easy, but humans find harder to read"
+msgstr ""
+
+#: cove/templates/stats.html:4
+msgid "Usage stats"
+msgstr ""
+
+#: cove/templates/stats.html:19
+#, python-format
+msgid "Last %(num_days)s days"
 msgstr ""
 
 #: cove/templates/terms.html:6
@@ -391,18 +465,20 @@ msgstr ""
 msgid ""
 "If you continue to browse and use this website, you are agreeing to comply "
 "with and be bound by the following terms and conditions of use, which "
-"together with our privacy policy govern Open Data Services Limited's "
-"relationship with you in relation to this website. If you disagree with any "
-"part of these terms and conditions, please do not use our website."
+"together with our privacy policy govern Open Data Services Co-operative "
+"Limited's relationship with you in relation to this website. If you disagree "
+"with any part of these terms and conditions, please do not use our website."
 msgstr ""
 
 #: cove/templates/terms.html:13
 msgid ""
-"The term 'Open Data Services Limited' or 'us' or 'we' refers to the owner of "
-"the website. Our company registration number is 09506232. There is more "
-"company information on the <a href=\"https://opencorporates.com/companies/"
-"gb/09506232\">Open Data Services Limited page at Open Corporates</a>. The "
-"term 'you' refers to the user or viewer of our website."
+"The term 'Open Data Services Co-operative Limited' or 'us' or 'we' refers to "
+"the owner of the website. Our company registration number is 09506232. Our "
+"registered address is 32 Church Road, Hove, East Sussex, England, BN3 2FN. "
+"There is more company information on the <a href=\"https://opencorporates."
+"com/companies/gb/09506232\">Open Data Services Co-operative Limited page at "
+"Open Corporates</a>. The term 'you' refers to the user or viewer of our "
+"website."
 msgstr ""
 
 #: cove/templates/terms.html:15
@@ -563,9 +639,10 @@ msgstr ""
 
 #: cove/templates/terms.html:73
 msgid ""
-"Open Data Services Limited keep server logs of traffic to, and activity on, "
-"our all of our servers. Primarily this is to help us keep our servers "
-"healthy and working by knowing how much activity is taking place on them."
+"Open Data Services Co-operative Limited keep server logs of traffic to, and "
+"activity on, our all of our servers. Primarily this is to help us keep our "
+"servers healthy and working by knowing how much activity is taking place on "
+"them."
 msgstr ""
 
 #: cove/templates/terms.html:75
@@ -589,25 +666,25 @@ msgstr ""
 
 #: cove/templates/terms.html:79
 msgid ""
-"This privacy policy sets out how Open Data Services Limited uses and "
-"protects any information that you give Open Data Services Limited when you "
-"use this website."
+"This privacy policy sets out how Open Data Services Co-operative Limited "
+"uses and protects any information that you give Open Data Services Co-"
+"operative Limited when you use this website."
 msgstr ""
 
 #: cove/templates/terms.html:81
 msgid ""
-"Open Data Services Limited is committed to ensuring that your privacy is "
-"protected. Should we ask you to provide certain information by which you can "
-"be identified when using this website, then you can be assured that it will "
-"only be used in accordance with this privacy statement."
+"Open Data Services Co-operative Limited is committed to ensuring that your "
+"privacy is protected. Should we ask you to provide certain information by "
+"which you can be identified when using this website, then you can be assured "
+"that it will only be used in accordance with this privacy statement."
 msgstr ""
 
 #: cove/templates/terms.html:83
 msgid ""
-"Open Data Services Limited may change this policy from time to time by "
-"updating this page. You should check this page from time to time to ensure "
-"that you are happy with any changes. This policy is effective from 1st April "
-"2015."
+"Open Data Services Co-operative Limited may change this policy from time to "
+"time by updating this page. You should check this page from time to time to "
+"ensure that you are happy with any changes. This policy is effective from "
+"1st April 2015."
 msgstr ""
 
 #: cove/templates/terms.html:85
@@ -631,16 +708,16 @@ msgstr ""
 #: cove/templates/terms.html:90
 msgid ""
 "\n"
-"  Open Data Services Limited does not make use of any of the data within the "
-"files for purposes other than to create reports for you about the data you "
-"have submitted."
+"  Open Data Services Co-operative Limited does not make use of any of the "
+"data within the files for purposes other than to create reports for you "
+"about the data you have submitted."
 msgstr ""
 
 #: cove/templates/terms.html:93
 msgid ""
-"Open Data Services Limited does create and store metadata about your use of "
-"the application, and about the files/data that you have uploaded in order to "
-"monitor how the application is being used."
+"Open Data Services Co-operative Limited does create and store metadata about "
+"your use of the application, and about the files/data that you have uploaded "
+"in order to monitor how the application is being used."
 msgstr ""
 
 #: cove/templates/terms.html:95
@@ -685,8 +762,10 @@ msgid ""
 "hold about you under the Data Protection Act 1998. A small fee will be "
 "payable. If you would like a copy of the information held on you please "
 "email the Data Protection Officer at company@opendataservices.coop. If you "
-"would like to write to us our contact details are available on the Open Data "
-"Services Limited page at Open Corporates."
+"would like to write to us our registered addresess is 32 Church Road, Hove, "
+"East Sussex, England, BN3 2FN. Further details are available on the <a href="
+"\"https://opencorporates.com/companies/gb/09506232\">Open Data Services Co-"
+"operative Limited page at Open Corporates</a>."
 msgstr ""
 
 #: cove/templates/terms.html:108
@@ -730,41 +809,42 @@ msgstr ""
 #: cove/templates/terms.html:117
 msgid ""
 "The information contained in this website is for general information "
-"purposes only. The information is provided by Open Data Services Limited and "
-"while we endeavour to keep the information up to date and correct, we make "
-"no representations or warranties of any kind, express or implied, about the "
-"completeness, accuracy, reliability, suitability or availability with "
-"respect to the website or the information, products, services, or related "
-"graphics contained on the website for any purpose. Any reliance you place on "
-"such information is therefore strictly at your own risk.\n"
+"purposes only. The information is provided by Open Data Services Co-"
+"operative Limited and while we endeavour to keep the information up to date "
+"and correct, we make no representations or warranties of any kind, express "
+"or implied, about the completeness, accuracy, reliability, suitability or "
+"availability with respect to the website or the information, products, "
+"services, or related graphics contained on the website for any purpose. Any "
+"reliance you place on such information is therefore strictly at your own "
+"risk.\n"
 "  In no event will we be liable for any loss or damage including without "
 "limitation, indirect or consequential loss or damage, or any loss or damage "
 "whatsoever arising from loss of data or profits arising out of, or in "
 "connection with, the use of this website.\n"
 "  Through this website you are able to link to other websites which are not "
-"under the control of Open Data Services Limited. We have no control over the "
-"nature, content and availability of those sites. The inclusion of any links "
-"does not necessarily imply a recommendation or endorse the views expressed "
-"within them.\n"
+"under the control of Open Data Services Co-operative Limited. We have no "
+"control over the nature, content and availability of those sites. The "
+"inclusion of any links does not necessarily imply a recommendation or "
+"endorse the views expressed within them.\n"
 "  Every effort is made to keep the website up and running smoothly. However, "
-"Open Data Services Limited takes no responsibility for, and will not be "
-"liable for, the website being temporarily unavailable due to technical "
-"issues beyond our control."
+"Open Data Services Co-operative Limited takes no responsibility for, and "
+"will not be liable for, the website being temporarily unavailable due to "
+"technical issues beyond our control."
 msgstr ""
 
-#: cove/views.py:101 cove/views.py:111
+#: cove/views.py:108 cove/views.py:118
 msgid "Sorry, the page you are looking for is not available"
 msgstr ""
 
-#: cove/views.py:103 cove/views.py:113
+#: cove/views.py:110 cove/views.py:120
 msgid "Go to Home page"
 msgstr ""
 
-#: cove/views.py:104
+#: cove/views.py:111
 msgid "We don't seem to be able to find the data you requested."
 msgstr ""
 
-#: cove/views.py:114
+#: cove/views.py:121
 msgid ""
 "The data you were hoping to explore no longer exists.\n"
 "\n"
@@ -772,24 +852,24 @@ msgid ""
 "after 7 days, and therefore the analysis of that data is no longer available."
 msgstr ""
 
-#: cove/views.py:121 cove/views.py:152
+#: cove/views.py:128 cove/views.py:159
 msgid "Sorry we can't process that data"
 msgstr ""
 
-#: cove/views.py:123 cove/views.py:154
+#: cove/views.py:130 cove/views.py:161
 msgid "Try Again"
 msgstr ""
 
-#: cove/views.py:124
+#: cove/views.py:131
 msgid ""
 "We did not recognise the file type.\n"
 "\n"
-"We can only process json, xls, xlsx and csv files.\n"
+"We can only process json, csv and xlsx files.\n"
 "\n"
 "Is this a bug? Contact us on code [at] opendataservices.coop"
 msgstr ""
 
-#: cove/views.py:155
+#: cove/views.py:162
 msgid ""
 "We think you tried to upload a JSON file, but it is not well formed JSON.\n"
 "\n"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-18 10:03+0000\n"
+"POT-Creation-Date: 2015-08-10 12:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
 "2:1));\n"
 
-#: cove/input/templates/datainput/input.html:12
+#: cove/input/templates/datainput/input.html:12 cove/templates/stats.html:10
 msgid "Upload"
 msgstr "Încărcați"
 
@@ -29,11 +29,12 @@ msgstr "Încărcați"
 msgid "Submit"
 msgstr "Prezenta"
 
-#: cove/input/templates/datainput/input.html:33
+#: cove/input/templates/datainput/input.html:33 cove/templates/stats.html:11
 msgid "Link"
 msgstr "Legătură"
 
 #: cove/input/templates/datainput/input.html:54 cove/input/views.py:28
+#: cove/templates/stats.html:12
 msgid "Paste"
 msgstr "Pastă"
 
@@ -45,24 +46,36 @@ msgstr "Încărcați un fișier"
 msgid "Supply a URL"
 msgstr "Furnizează o adresă URL"
 
-#: cove/settings.py:45 cove/templates/multi_index.html:8
+#: cove/settings.py:45 cove/templates/multi_index.html:28
 msgid "Open Contracting Data Tool"
 msgstr ""
 
-#: cove/settings.py:46
-msgid "360 Giving Data Tool"
+#: cove/settings.py:46 cove/templates/multi_index.html:16
+msgid "360Giving Data Tool"
 msgstr ""
 
 #: cove/settings.py:47
-msgid "Cove"
+msgid "CoVE"
+msgstr ""
+
+#: cove/settings.py:50
+msgid "Convert, Validate, Explore Open Contracting Data"
+msgstr ""
+
+#: cove/settings.py:51
+msgid "Convert, Validate, Explore 360Giving Data"
+msgstr ""
+
+#: cove/settings.py:52
+msgid "Convert, Validate, Explore"
 msgstr ""
 
 #: cove/templates/base_360.html:5
-msgid "Three Sixty Degree Giving"
+msgid "360Giving"
 msgstr ""
 
-#: cove/templates/base_360.html:6
-msgid "360 Giving Data Standard"
+#: cove/templates/base_360.html:6 cove/templates/multi_index.html:14
+msgid "360Giving Data Standard"
 msgstr ""
 
 #: cove/templates/base_360.html:11 cove/templates/base_ocds.html:11
@@ -74,7 +87,7 @@ msgstr "Cum să utilizați %(application_name)s"
 #: cove/templates/base_360.html:13
 msgid ""
 "\n"
-"  Upload, paste or provide a link to data in the 360 Giving Data Standard "
+"  Upload, paste or provide a link to data in the 360Giving Data Standard "
 "format, and this application will convert between JSON, Excel and CSV "
 "formats, allowing you to download the original file, and the converted "
 "versions."
@@ -94,79 +107,74 @@ msgstr ""
 msgid ""
 "\n"
 "  The application accepts data in some of the formats given in the <a href="
-"\"http://docs.threesixtygiving.org/publish/\">360 Giving Data Standard "
-"publishing guidence</a> under <a href=\"http://docs.threesixtygiving.org/"
-"publish/#toc1\">Choose your template</a>.\n"
+"\"http://www.threesixtygiving.org/standard/\">360Giving Data Standard "
+"guidence</a>.\n"
 "  <br>Acceptable files are: "
 msgstr ""
 
 #: cove/templates/base_360.html:23
 msgid ""
-"Summary Spreadsheet - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/summary-table/360-giving-schema-titles.xlsx\">Excel</a>"
+"Summary Spreadsheet - <a href=\"https://github.com/ThreeSixtyGiving/standard/"
+"raw/master/schema/summary-table/360-giving-schema-titles.xlsx\">Excel</a>, "
+"<a href=\"https://github.com/ThreeSixtyGiving/standard/raw/master/schema/"
+"summary-table/360-giving-schema-titles.csv/grants.csv\">CSV</a>"
 msgstr ""
 
 #: cove/templates/base_360.html:24
 msgid ""
-"Summary Spreadsheet - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/summary-table/360-giving-schema-titles.csv/Activity.csv"
-"\">CSV</a>"
+"JSON built to the <a href=\"http://www.threesixtygiving.org/standard/"
+"reference/#toc-json-schema\">360Giving Data Standard JSON schema</a>"
 msgstr ""
 
 #: cove/templates/base_360.html:25
 msgid ""
-"JSON built to the <a href=\"http://docs.threesixtygiving.org/docs/#json-"
-"schema\">360 Giving Data Standard JSON schema</a>"
-msgstr ""
-
-#: cove/templates/base_360.html:26
-msgid ""
-"Multi-table data package - <a href=\"http://docs.threesixtygiving.org/assets/"
-"standard/schema/multi-table/360-giving-schema-fields.xlsx\">Excel</a>"
+"<a href=\"https://github.com/ThreeSixtyGiving/standard/raw/master/schema/"
+"multi-table/360-giving-schema-fields.xlsx\">Multi-table data package - "
+"Excel</a>"
 msgstr ""
 
 #. Translators: Label of a button that triggers search
-#: cove/templates/base_generic.html:38
+#: cove/templates/base_generic.html:40
 msgid "Go"
 msgstr "Merge"
 
-#: cove/templates/base_generic.html:57
+#: cove/templates/base_generic.html:59
 msgid "What happens to the data I provide to this site?"
 msgstr ""
 
-#: cove/templates/base_generic.html:58
+#: cove/templates/base_generic.html:60
 msgid ""
 "We retain the data you upload or paste to this site, on our server, for 7 "
 "days."
 msgstr ""
 
-#: cove/templates/base_generic.html:59
+#: cove/templates/base_generic.html:61
 msgid ""
 "If you supply a link, we fetch the data from that link and store it on our "
 "server for 7 days."
 msgstr ""
 
-#: cove/templates/base_generic.html:60
+#: cove/templates/base_generic.html:62
 msgid ""
 "We delete all data older than 7 days from our servers daily, retaining none "
 "of the original data."
 msgstr ""
 
-#: cove/templates/base_generic.html:61
+#: cove/templates/base_generic.html:63
 msgid ""
 "While the data is on our servers we may access that data to help us "
 "understand how people are using this application, what types of data are "
 "being supplied, what common errors exist and so on."
 msgstr ""
 
-#: cove/templates/base_generic.html:62
+#: cove/templates/base_generic.html:64
 msgid ""
 "We may also retain data in backups of our servers, which means on occassion, "
 "some data may be retained longer. We have no intention of using this data "
 "for anything other than server recovery in an emergency."
 msgstr ""
 
-#: cove/templates/base_generic.html:63
+#: cove/templates/base_generic.html:65
 msgid ""
 "We do retain some metadata about data supplied to this site. Details can be "
 "found in the code, but may include information about whether or not the file "
@@ -174,11 +182,11 @@ msgid ""
 "supplied and so on. "
 msgstr ""
 
-#: cove/templates/base_generic.html:65
+#: cove/templates/base_generic.html:67
 msgid "Why do you delete data after 7 days?"
 msgstr ""
 
-#: cove/templates/base_generic.html:66
+#: cove/templates/base_generic.html:68
 msgid ""
 "This is service to allow people to explore machine readable data. As such we "
 "see no need to store and gather everything people submit to the site "
@@ -187,17 +195,17 @@ msgid ""
 "to save people having to clean up after themselves."
 msgstr ""
 
-#: cove/templates/base_generic.html:67
+#: cove/templates/base_generic.html:69
 msgid ""
 "We believe that deleting supplied data after 7 days provides a level of "
 "privacy for the users of this service. "
 msgstr ""
 
-#: cove/templates/base_generic.html:73
+#: cove/templates/base_generic.html:75
 msgid "Why provide converted versions?"
 msgstr ""
 
-#: cove/templates/base_generic.html:74
+#: cove/templates/base_generic.html:76
 msgid ""
 "\n"
 "    The W3C <a href=\"http://www.w3.org/TR/dwbp/\">Data on the Web Best "
@@ -207,59 +215,59 @@ msgid ""
 "    "
 msgstr ""
 
-#: cove/templates/base_generic.html:86
+#: cove/templates/base_generic.html:88
 msgid "About"
 msgstr ""
 
-#: cove/templates/base_generic.html:88
+#: cove/templates/base_generic.html:90
 msgid "Built by"
 msgstr ""
 
-#: cove/templates/base_generic.html:88
-msgid "Open Data Services Co-operative"
+#: cove/templates/base_generic.html:90
+msgid "Open Data Services"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "The code for this site is available on"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "GitHub"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Cove - COnvert Validate & Explore"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Licence"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "AGPLv3"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Report/View issues"
 msgstr ""
 
-#: cove/templates/base_generic.html:89
+#: cove/templates/base_generic.html:91
 msgid "Cove Issues"
 msgstr ""
 
-#: cove/templates/base_generic.html:93
+#: cove/templates/base_generic.html:95
 msgid "Terms &amp; Conditions"
 msgstr ""
 
 #. Translators: Provides information about the version of the code base that is being used
-#: cove/templates/base_generic.html:96
+#: cove/templates/base_generic.html:98
 #, python-format
 msgid ""
 "Running version <a href=\"https://github.com/OpenDataServices/cove/tree/"
 "%(version)s\">%(version)s</a>."
 msgstr ""
 
-#: cove/templates/base_generic.html:99
+#: cove/templates/base_generic.html:101
 #, fuzzy
 #| msgid "Link"
 msgid "Links"
@@ -269,7 +277,7 @@ msgstr "Legătură"
 msgid "Open Contracting"
 msgstr ""
 
-#: cove/templates/base_ocds.html:6
+#: cove/templates/base_ocds.html:6 cove/templates/multi_index.html:26
 msgid "Open Contracting Data Standard"
 msgstr ""
 
@@ -306,78 +314,146 @@ msgstr "Foaie de calcul Excel (.xlsx)"
 #: cove/templates/explore.html:8
 #, fuzzy
 #| msgid "Excel Spreadsheet (.xlsx)"
+msgid "CSV Spreadsheet (.csv)"
+msgstr "Foaie de calcul Excel (.xlsx)"
+
+#: cove/templates/explore.html:9
+#, fuzzy
+#| msgid "Excel Spreadsheet (.xlsx)"
 msgid "Excel Spreadsheet (.xlsx) with titles"
 msgstr "Foaie de calcul Excel (.xlsx)"
 
 #. Translators: JSON probably does not need a transalation: http://www.json.org/
-#: cove/templates/explore.html:10
+#: cove/templates/explore.html:11
 msgid "JSON"
 msgstr "JSON"
 
-#: cove/templates/explore.html:16
+#: cove/templates/explore.html:17
 msgid "Download Files"
 msgstr "Descărca fișiere"
 
-#: cove/templates/explore.html:23 cove/templates/explore.html.py:24
-#: cove/templates/explore.html:25 cove/templates/explore.html.py:29
-#: cove/templates/explore.html:30
+#: cove/templates/explore.html:24 cove/templates/explore.html.py:25
+#: cove/templates/explore.html:26 cove/templates/explore.html.py:32
+#: cove/templates/explore.html:34 cove/templates/explore.html.py:37
 #, python-format
 msgid "%(file_format)s (%(status)s)"
 msgstr "%(file_format)s (%(status)s)"
 
-#: cove/templates/explore.html:43
+#: cove/templates/explore.html:50
 msgid "Validates against the schema?"
 msgstr ""
 
-#: cove/templates/explore.html:58
+#: cove/templates/explore.html:65
 #, fuzzy
 #| msgid "Number of Releases"
 msgid "Number of releases"
 msgstr "Numărul de presă"
 
-#: cove/templates/explore.html:69
+#: cove/templates/explore.html:76
 #, python-format
 msgid "Unique OCIDs (%(number_of_ocids)s)"
 msgstr ""
 
-#: cove/templates/explore.html:85
+#: cove/templates/explore.html:92
 msgid "Release Dates"
 msgstr ""
 
-#: cove/templates/explore.html:89
+#: cove/templates/explore.html:96
 msgid "Earliest:"
 msgstr ""
 
-#: cove/templates/explore.html:91
+#: cove/templates/explore.html:98
 msgid "Latest:"
 msgstr ""
 
-#: cove/templates/explore.html:99
+#: cove/templates/explore.html:106
 msgid "Releases Table:"
 msgstr ""
 
-#: cove/templates/explore.html:123
+#: cove/templates/explore.html:136
 #, fuzzy
 #| msgid "Number of Releases"
 msgid "Number of grants"
 msgstr "Numărul de presă"
 
-#: cove/templates/explore.html:135
+#: cove/templates/explore.html:148
+#, python-format
+msgid "Unique IDs (%(number_of_ids)s)"
+msgstr ""
+
+#: cove/templates/explore.html:164
+msgid "Grants Table:"
+msgstr ""
+
+#: cove/templates/explore.html:190
 msgid "Save or Share these results"
 msgstr ""
 
 #. Translators: Paragraph that describes the application
-#: cove/templates/explore.html:137
+#: cove/templates/explore.html:192
 msgid ""
 "These results will be available for 7 days from the day the data was first "
 "uploaded. You can revisit these results until then."
 msgstr ""
 
-#: cove/templates/explore.html:139
+#: cove/templates/explore.html:194
 msgid ""
 "After 7 days all uploaded data is deleted from our servers, and the results "
 "will no longer be available. Anyone using the link to this page after that "
 "will be show a message that tells them the file has been removed."
+msgstr ""
+
+#: cove/templates/multi_index.html:12
+msgid "360Giving Logo"
+msgstr ""
+
+#: cove/templates/multi_index.html:15
+msgid ""
+"360Giving provides support for grantmakers to publish their grants data "
+"openly, to understand their data, and to use the data to create online tools "
+"that make grant-making more effective."
+msgstr ""
+
+#: cove/templates/multi_index.html:24
+msgid "Open Contracting Logo"
+msgstr ""
+
+#: cove/templates/multi_index.html:27
+msgid ""
+"The Open Contracting Data Standard promotes the effective use of contracting "
+"data, helping users to “follow the money”, and it provides a clear template "
+"for governments wishing to disclose their data."
+msgstr ""
+
+#: cove/templates/multi_index.html:35
+msgid ""
+"Creating and using Open Data is made easier when there are good tools to "
+"help."
+msgstr ""
+
+#: cove/templates/multi_index.html:36
+msgid "CoVE exisits to help people:"
+msgstr ""
+
+#: cove/templates/multi_index.html:38
+msgid "Convert data between common formats (e.g. csv to json)"
+msgstr ""
+
+#: cove/templates/multi_index.html:39
+msgid "Validate data against rules"
+msgstr ""
+
+#: cove/templates/multi_index.html:40
+msgid "Explore data, that machines find easy, but humans find harder to read"
+msgstr ""
+
+#: cove/templates/stats.html:4
+msgid "Usage stats"
+msgstr ""
+
+#: cove/templates/stats.html:19
+#, python-format
+msgid "Last %(num_days)s days"
 msgstr ""
 
 #: cove/templates/terms.html:6
@@ -400,18 +476,20 @@ msgstr ""
 msgid ""
 "If you continue to browse and use this website, you are agreeing to comply "
 "with and be bound by the following terms and conditions of use, which "
-"together with our privacy policy govern Open Data Services Limited's "
-"relationship with you in relation to this website. If you disagree with any "
-"part of these terms and conditions, please do not use our website."
+"together with our privacy policy govern Open Data Services Co-operative "
+"Limited's relationship with you in relation to this website. If you disagree "
+"with any part of these terms and conditions, please do not use our website."
 msgstr ""
 
 #: cove/templates/terms.html:13
 msgid ""
-"The term 'Open Data Services Limited' or 'us' or 'we' refers to the owner of "
-"the website. Our company registration number is 09506232. There is more "
-"company information on the <a href=\"https://opencorporates.com/companies/"
-"gb/09506232\">Open Data Services Limited page at Open Corporates</a>. The "
-"term 'you' refers to the user or viewer of our website."
+"The term 'Open Data Services Co-operative Limited' or 'us' or 'we' refers to "
+"the owner of the website. Our company registration number is 09506232. Our "
+"registered address is 32 Church Road, Hove, East Sussex, England, BN3 2FN. "
+"There is more company information on the <a href=\"https://opencorporates."
+"com/companies/gb/09506232\">Open Data Services Co-operative Limited page at "
+"Open Corporates</a>. The term 'you' refers to the user or viewer of our "
+"website."
 msgstr ""
 
 #: cove/templates/terms.html:15
@@ -572,9 +650,10 @@ msgstr ""
 
 #: cove/templates/terms.html:73
 msgid ""
-"Open Data Services Limited keep server logs of traffic to, and activity on, "
-"our all of our servers. Primarily this is to help us keep our servers "
-"healthy and working by knowing how much activity is taking place on them."
+"Open Data Services Co-operative Limited keep server logs of traffic to, and "
+"activity on, our all of our servers. Primarily this is to help us keep our "
+"servers healthy and working by knowing how much activity is taking place on "
+"them."
 msgstr ""
 
 #: cove/templates/terms.html:75
@@ -598,25 +677,25 @@ msgstr ""
 
 #: cove/templates/terms.html:79
 msgid ""
-"This privacy policy sets out how Open Data Services Limited uses and "
-"protects any information that you give Open Data Services Limited when you "
-"use this website."
+"This privacy policy sets out how Open Data Services Co-operative Limited "
+"uses and protects any information that you give Open Data Services Co-"
+"operative Limited when you use this website."
 msgstr ""
 
 #: cove/templates/terms.html:81
 msgid ""
-"Open Data Services Limited is committed to ensuring that your privacy is "
-"protected. Should we ask you to provide certain information by which you can "
-"be identified when using this website, then you can be assured that it will "
-"only be used in accordance with this privacy statement."
+"Open Data Services Co-operative Limited is committed to ensuring that your "
+"privacy is protected. Should we ask you to provide certain information by "
+"which you can be identified when using this website, then you can be assured "
+"that it will only be used in accordance with this privacy statement."
 msgstr ""
 
 #: cove/templates/terms.html:83
 msgid ""
-"Open Data Services Limited may change this policy from time to time by "
-"updating this page. You should check this page from time to time to ensure "
-"that you are happy with any changes. This policy is effective from 1st April "
-"2015."
+"Open Data Services Co-operative Limited may change this policy from time to "
+"time by updating this page. You should check this page from time to time to "
+"ensure that you are happy with any changes. This policy is effective from "
+"1st April 2015."
 msgstr ""
 
 #: cove/templates/terms.html:85
@@ -640,16 +719,16 @@ msgstr ""
 #: cove/templates/terms.html:90
 msgid ""
 "\n"
-"  Open Data Services Limited does not make use of any of the data within the "
-"files for purposes other than to create reports for you about the data you "
-"have submitted."
+"  Open Data Services Co-operative Limited does not make use of any of the "
+"data within the files for purposes other than to create reports for you "
+"about the data you have submitted."
 msgstr ""
 
 #: cove/templates/terms.html:93
 msgid ""
-"Open Data Services Limited does create and store metadata about your use of "
-"the application, and about the files/data that you have uploaded in order to "
-"monitor how the application is being used."
+"Open Data Services Co-operative Limited does create and store metadata about "
+"your use of the application, and about the files/data that you have uploaded "
+"in order to monitor how the application is being used."
 msgstr ""
 
 #: cove/templates/terms.html:95
@@ -694,8 +773,10 @@ msgid ""
 "hold about you under the Data Protection Act 1998. A small fee will be "
 "payable. If you would like a copy of the information held on you please "
 "email the Data Protection Officer at company@opendataservices.coop. If you "
-"would like to write to us our contact details are available on the Open Data "
-"Services Limited page at Open Corporates."
+"would like to write to us our registered addresess is 32 Church Road, Hove, "
+"East Sussex, England, BN3 2FN. Further details are available on the <a href="
+"\"https://opencorporates.com/companies/gb/09506232\">Open Data Services Co-"
+"operative Limited page at Open Corporates</a>."
 msgstr ""
 
 #: cove/templates/terms.html:108
@@ -739,41 +820,42 @@ msgstr ""
 #: cove/templates/terms.html:117
 msgid ""
 "The information contained in this website is for general information "
-"purposes only. The information is provided by Open Data Services Limited and "
-"while we endeavour to keep the information up to date and correct, we make "
-"no representations or warranties of any kind, express or implied, about the "
-"completeness, accuracy, reliability, suitability or availability with "
-"respect to the website or the information, products, services, or related "
-"graphics contained on the website for any purpose. Any reliance you place on "
-"such information is therefore strictly at your own risk.\n"
+"purposes only. The information is provided by Open Data Services Co-"
+"operative Limited and while we endeavour to keep the information up to date "
+"and correct, we make no representations or warranties of any kind, express "
+"or implied, about the completeness, accuracy, reliability, suitability or "
+"availability with respect to the website or the information, products, "
+"services, or related graphics contained on the website for any purpose. Any "
+"reliance you place on such information is therefore strictly at your own "
+"risk.\n"
 "  In no event will we be liable for any loss or damage including without "
 "limitation, indirect or consequential loss or damage, or any loss or damage "
 "whatsoever arising from loss of data or profits arising out of, or in "
 "connection with, the use of this website.\n"
 "  Through this website you are able to link to other websites which are not "
-"under the control of Open Data Services Limited. We have no control over the "
-"nature, content and availability of those sites. The inclusion of any links "
-"does not necessarily imply a recommendation or endorse the views expressed "
-"within them.\n"
+"under the control of Open Data Services Co-operative Limited. We have no "
+"control over the nature, content and availability of those sites. The "
+"inclusion of any links does not necessarily imply a recommendation or "
+"endorse the views expressed within them.\n"
 "  Every effort is made to keep the website up and running smoothly. However, "
-"Open Data Services Limited takes no responsibility for, and will not be "
-"liable for, the website being temporarily unavailable due to technical "
-"issues beyond our control."
+"Open Data Services Co-operative Limited takes no responsibility for, and "
+"will not be liable for, the website being temporarily unavailable due to "
+"technical issues beyond our control."
 msgstr ""
 
-#: cove/views.py:101 cove/views.py:111
+#: cove/views.py:108 cove/views.py:118
 msgid "Sorry, the page you are looking for is not available"
 msgstr ""
 
-#: cove/views.py:103 cove/views.py:113
+#: cove/views.py:110 cove/views.py:120
 msgid "Go to Home page"
 msgstr ""
 
-#: cove/views.py:104
+#: cove/views.py:111
 msgid "We don't seem to be able to find the data you requested."
 msgstr ""
 
-#: cove/views.py:114
+#: cove/views.py:121
 msgid ""
 "The data you were hoping to explore no longer exists.\n"
 "\n"
@@ -781,24 +863,24 @@ msgid ""
 "after 7 days, and therefore the analysis of that data is no longer available."
 msgstr ""
 
-#: cove/views.py:121 cove/views.py:152
+#: cove/views.py:128 cove/views.py:159
 msgid "Sorry we can't process that data"
 msgstr ""
 
-#: cove/views.py:123 cove/views.py:154
+#: cove/views.py:130 cove/views.py:161
 msgid "Try Again"
 msgstr ""
 
-#: cove/views.py:124
+#: cove/views.py:131
 msgid ""
 "We did not recognise the file type.\n"
 "\n"
-"We can only process json, xls, xlsx and csv files.\n"
+"We can only process json, csv and xlsx files.\n"
 "\n"
 "Is this a bug? Contact us on code [at] opendataservices.coop"
 msgstr ""
 
-#: cove/views.py:155
+#: cove/views.py:162
 msgid ""
 "We think you tried to upload a JSON file, but it is not well formed JSON.\n"
 "\n"


### PR DESCRIPTION
Also alters the main site page title to CoVE
Adds tests to check links go to appropriate URL
Checks footer link to see that they actually click through to the
correct sites and see appropriate text. These might not be all that clever
in the longer term, but should flag significant changes perhaps.
Re-runs translastions as some text has been altered