### PR TITLE
[#81] Should fix tests against appropriate banner for  live or dev

### DIFF
--- a/fts/tests.py
+++ b/fts/tests.py
@@ -24,6 +24,8 @@ def server_url(request, live_server):
 def test_index_page_banner(server_url, browser):
     browser.get(server_url)
     assert 'This tool is alpha. Please report any problems on GitHub issues.' in browser.find_element_by_tag_name('body').text
+    if server_url == "http://dev.cove.opendataservices.coop/":
+        assert 'This is a development site with experimental features. Do not rely on it.' in browser.find_element_by_tag_name('body').text
     
 
 def test_index_page(server_url, browser):


### PR DESCRIPTION
By checking the server_url in the banner test we should get the
correct behaviour?

<!---
@huboard:{"order":1.2781372259778436,"milestone_order":86,"custom_state":""}
-->
