### PR TITLE
[#45] Allow source_url as get param

### DIFF
--- a/cove/input/views.py
+++ b/cove/input/views.py
@@ -34,14 +34,20 @@ def input(request):
         'text_form': TextForm,
     }
     forms = {form_name: form_class() for form_name, form_class in form_classes.items()}
-    if request.method == 'POST':
-        if 'source_url' in request.POST:
+
+    request_data = None
+    if "source_url" in request.GET:
+        request_data = request.GET
+    if request.POST:
+        request_data = request.POST
+    if request_data:
+        if 'source_url' in request_data:
             form_name = 'url_form'
-        elif 'paste' in request.POST:
+        elif 'paste' in request_data:
             form_name = 'text_form'
         else:
             form_name = 'upload_form'
-        form = form_classes[form_name](request.POST, request.FILES)
+        form = form_classes[form_name](request_data, request.FILES)
         forms[form_name] = form
         if form.is_valid():
             if form_name == 'text_form':
@@ -56,4 +62,5 @@ def input(request):
             elif form_name == 'text_form':
                 data.original_file.save('test.json', ContentFile(form['paste'].value()))
             return redirect(data.get_absolute_url())
+
     return render(request, 'datainput/input.html', {'forms': forms})

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -175,10 +175,16 @@ def test_URL_input(server_url, browser, httpserver, source_filename, prefix, exp
     time.sleep(0.5)
     browser.find_element_by_id('id_source_url').send_keys(source_url)
     browser.find_element_by_css_selector("#fetchURL > div.form-group > button.btn.btn-primary").click()
+    check_url_input_result_page(server_url, browser, httpserver, source_filename, prefix, expected_text, conversion_successful)
+    
+    browser.get(server_url + prefix + '?source_url=' + source_url)
+    check_url_input_result_page(server_url, browser, httpserver, source_filename, prefix, expected_text, conversion_successful)
+
+
+def check_url_input_result_page(server_url, browser, httpserver, source_filename, prefix, expected_text, conversion_successful):
+    # We should still be in the correct app
     body_text = browser.find_element_by_tag_name('body').text
     assert expected_text in body_text
-    
-    # We should still be in the correct app
     if prefix == '/ocds/':
         assert 'Open Contracting Data Tool' in browser.find_element_by_tag_name('body').text
         # # Look for Release Table


### PR DESCRIPTION
If source_url is in the GET params then use GET params instead of POST params to pass to django forms.
CSRF check do not happen on GET requests, so there is no major complication here.

Repeat all functional tests where source_url entered in the form and pass them as GET params as well.