### PR TITLE
[#174] Add 360 key metric information

### DIFF
--- a/cove/fixtures/WellcomeTrust-grants_fixed_2_grants.json
+++ b/cove/fixtures/WellcomeTrust-grants_fixed_2_grants.json
@@ -38,6 +38,82 @@
             "awardDate": "24/07/2014"
         }, 
         {
+            "currency": "GBP", 
+            "grantProgramme": [
+                {
+                    "code": "AAC", 
+                    "title": "Arts Awards Funding Committee"
+                }
+            ], 
+            "id": "360G-wellcometrust-105177/Z/14/Z", 
+            "Co-applicant(s)": "Mr Bentley Crudgington, Mr Gary Thomas", 
+            "title": "Silent Signal.", 
+            "fundingOrganization": [
+                {
+                    "id": "GB-CHC-210183", 
+                    "name": "The Wellcome Trust"
+                }
+            ], 
+            "dateModified": "13-03-2015", 
+            "Data source": "http://www.wellcome.ac.uk/Managing-a-grant/Grants-awarded/index.htm", 
+            "plannedDates": [
+                {
+                    "duration": 30
+                }
+            ], 
+            "Surname of applicant": "Addison", 
+            "Grant number": "105177/Z/14/Z", 
+            "amountAwarded": 152505, 
+            "recipientOrganization": [
+                {
+                    "addressLocality": "London", 
+                    "name": "Animate Project Limited"
+                }
+            ], 
+            "Grant type": "Large Arts Awards", 
+            "Full name of applicant": "Miss Abigail Addison", 
+            "awardDate": "24/07/2014"
+        }, 
+        {
+            "recipientOrganization": [
+                {
+                    "id": "GB-COH-RC000659", 
+                    "addressLocality": "Leicester", 
+                    "name": "UNIVERSITY OF LEICESTER", 
+                    "companyNumber": "RC000659"
+                }
+            ], 
+            "currency": "GBP", 
+            "grantProgramme": [
+                {
+                    "code": "AAC", 
+                    "title": "Arts Awards Funding Committee"
+                }
+            ], 
+            "Department": "Department of Museum Studies", 
+            "id": "360G-wellcometrust-105182/Z/14/Z", 
+            "title": "Exceptional and Extraordinary: unruly bodies and minds in the medical museum.", 
+            "fundingOrganization": [
+                {
+                    "id": "GB-CHC-210183", 
+                    "name": "The Wellcome Trust"
+                }
+            ], 
+            "dateModified": "13-03-2015", 
+            "Data source": "http://www.wellcome.ac.uk/Managing-a-grant/Grants-awarded/index.htm", 
+            "plannedDates": [
+                {
+                    "duration": 25
+                }
+            ], 
+            "Surname of applicant": "Sandell", 
+            "Grant number": "105182/Z/14/Z", 
+            "amountAwarded": 178990, 
+            "Grant type": "Large Arts Awards", 
+            "Full name of applicant": "Prof Richard Sandell", 
+            "awardDate": "24/07/2014"
+        }, 
+        {
             "recipientOrganization": [
                 {
                     "id": "GB-COH-RC000659", 

--- a/cove/templates/explore.html
+++ b/cove/templates/explore.html
@@ -2,6 +2,7 @@
 {% block content %}
 
 {% load i18n %}
+{% load cove_tags %}
 {% trans 'Converted from Original' as converted %}
 {% trans 'Original' as original %}
 {% trans 'Excel Spreadsheet (.xlsx)' as xlsx %} 
@@ -91,28 +92,10 @@
     </div>
 {% endif %}
 
-<!-- Count of Releases -->
-<div class="row">
-  {% if schema_url %}
 
-  <div class="col-md-3">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h4 class="panel-title">{% trans 'Validates against the schema?' %}</h4>
-      </div>
-      <div class="panel-body">
-        {% if validation_errors %}No{% else %}Yes{% endif %}
+{% block explore_content %}
+{% endblock %}
 
-      </div>
-    </div>
-  </div>
-
-  {% endif %}
-
-  {% block explore_content %}
-  {% endblock %}
-
-</div><!--End Row-->
 
 <div class="above-footer">
   <h2>{% trans "Save or Share these results" %}</h2>

--- a/cove/templates/explore_360.html
+++ b/cove/templates/explore_360.html
@@ -1,57 +1,115 @@
 {% extends 'explore.html' %}
 {% load i18n %}
+{% load cove_tags %}
 
 {% block explore_content %}
-  <div class="col-md-3">
-    <div class="panel panel-default">
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-primary">
       <div class="panel-heading">
-        <h4 class="panel-title">{% trans 'Number of grants' %}</h4>
+        <h4 class="panel-title">{% trans 'Key Field Information' %}</h4>
       </div>
       <div class="panel-body">
-        {{grants_aggregates.count}}
-      </div>
-    </div>
-  </div>
-  
-  <div class="col-md-3">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h4 class="panel-title">
-          {% blocktrans with number_of_ids=grants_aggregates.unique_ids|length %}Unique IDs ({{number_of_ids}}){% endblocktrans %}
-        </h4>
-      </div>
-      <div class="panel-body">
-        <ul>
-        {% for id in grants_aggregates.unique_ids %}
-        <li>{{id}}</li>
-        {% endfor %}
-        </ul>
+        <div class="row">
+          <div class="col-md-4">
+            <b>{% trans "Grants:" %}</b> {{grants_aggregates.count}}
+            <br/>
+            <b>{% trans "Grant IDs:" %}</b> {{grants_aggregates.id_count}}
+            <br/>
+            <a data-toggle="modal" data-target=".unique-ids">
+              <b>{% trans "Unique Grant IDs:" %}</b> {{grants_aggregates.unique_ids|length}}
+            </a>
+            <br/>
+            {% if grants_aggregates.duplicate_ids %}
+              <a data-toggle="modal" data-target=".duplicate-id-modal">
+                <b>{% trans "Duplicate IDs:" %}</b> {{grants_aggregates.duplicate_ids|length}}
+              </a>
+            {% else %}
+              <b>{% trans "Duplicate IDs:" %}</b> {{grants_aggregates.duplicate_ids|length}}
+            {% endif %}
+          </div>
+          <div class="col-md-4">
+            <b>{% trans "First Award Date:" %}</b> {{grants_aggregates.min_award_date}}
+            <br/>
+            <b>{% trans "Last Award Date:" %}</b> {{grants_aggregates.max_award_date}}
+            <br/>
+            <b>{% trans "Highest Award Amount:" %}</b> {{grants_aggregates.max_amount_awarded}}
+            <br/>
+            <b>{% trans "Lowest Award Amount:" %}</b> {{grants_aggregates.min_amount_awarded}}
+          </div>
+          <div class="col-md-4">
+            <a data-toggle="modal" data-target=".distinct-funding-org-identifier">
+              <b>{% trans "Funder Organisation IDs:" %}</b> {{grants_aggregates.distinct_funding_org_identifier|length}}
+            </a>
+            <br/>
+            <a data-toggle="modal" data-target=".distinct-recipient-org-identifier">
+              <b>{% trans "Recipient Organisations IDs:" %}</b> {{grants_aggregates.distinct_recipient_org_identifier|length}}
+            </a>
+            <br/>
+            <b>{% trans "Currencies Used Count:" %}</b> {{grants_aggregates.distinct_currency|length}}</td>
+            <br/>
+            <b>{% trans "Currencies Used:" %}</b> {{grants_aggregates.distinct_currency|join:", "}}</td>
+            <br/>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div><!--End Row -->
+
+{% cove_modal_list className="duplicate-id-modal" modalTitle="Duplicate IDs" itemList=grants_aggregates.duplicate_ids %}
+{% cove_modal_list className="distinct-recipient-org-identifier" modalTitle="Recipient Organisation IDs" itemList=grants_aggregates.distinct_recipient_org_identifier %}
+{% cove_modal_list className="distinct-funding-org-identifier" modalTitle="Funder Organisation IDs" itemList=grants_aggregates.distinct_funding_org_identifier %}
+{% cove_modal_list className="unique-ids" modalTitle="Unique IDs" itemList=grants_aggregates.unique_ids %}
+
+<div class="modal fade distinct-funding-orgs" tabindex="-1" role="dialog" aria-labelledby="duplicateIDS">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+         <h5 class="modal-title">Recipient Organisation IDs</h5>
+      </div>
+      <ul class="list-group">
+        {% for id in grants_aggregates.distinct_funding_org_identifier %}
+           <li class="list-group-item">{{ id }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+
+
 <div class="row"> <!--Start Row (Detail Table)-->
   <div class="col-md-12">
-    <table class="table table-striped">
-      <caption>{% trans "Grants Table:" %}</caption>
-      <thead>
-        <tr>
-          <th>id</th>
-          <th>title</th>
-          <th>amountAwarded</th>
-          <th>dateModified</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for grant in json_data.grants %}
-        <tr>
-          <td>{{ grant.id }}</td>
-          <td>{{ grant.title }}</td>
-          <td>{{ grant.amountAwarded }}</td> 
-          <td>{{ grant.dateModified }}</td>        
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          {% trans 'Grants Table' %}
+        </h4>
+      </div>
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>id</th>
+            <th>title</th>
+            <th>currency</th>
+            <th>amountAwarded</th>
+            <th>dateModified</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for grant in json_data.grants %}
+          <tr>
+            <td>{{ grant.id }}</td>
+            <td>{{ grant.title }}</td>
+            <td>{{ grant.currency }}</td>
+            <td>{{ grant.amountAwarded }}</td>
+            <td>{{ grant.dateModified }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
+</div><!--End Row-->
 {% endblock %}

--- a/cove/templates/explore_ocds-record.html
+++ b/cove/templates/explore_ocds-record.html
@@ -2,6 +2,22 @@
 {% load i18n %}
 
 {% block explore_content %}
+<div class="row">
+  {% if schema_url %}
+
+  <div class="col-md-3">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">{% trans 'Validates against the schema?' %}</h4>
+      </div>
+      <div class="panel-body">
+        {% if validation_errors %}No{% else %}Yes{% endif %}
+
+      </div>
+    </div>
+  </div>
+
+  {% endif %}
   <div class="col-md-3">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -53,4 +69,5 @@
       </tbody>
     </table>
   </div>
+</div><!--End Row -->
 {% endblock %}

--- a/cove/templates/explore_ocds-release.html
+++ b/cove/templates/explore_ocds-release.html
@@ -2,6 +2,22 @@
 {% load i18n %}
 
 {% block explore_content %}
+<div class="row">
+  {% if schema_url %}
+
+  <div class="col-md-3">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">{% trans 'Validates against the schema?' %}</h4>
+      </div>
+      <div class="panel-body">
+        {% if validation_errors %}No{% else %}Yes{% endif %}
+
+      </div>
+    </div>
+  </div>
+
+  {% endif %}
   <div class="col-md-3">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -71,4 +87,5 @@
       </tbody>
     </table>
   </div>
+</div><!--End Row -->
 {% endblock %}

--- a/cove/templates/modal_list.html
+++ b/cove/templates/modal_list.html
@@ -1,0 +1,15 @@
+<div class="modal {{className}}" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+         <h5 class="modal-title">{{ modalTitle }}</h5>
+      </div>
+      <ul class="list-group">
+        {% for id in itemList %}
+           <li class="list-group-item">{{ id }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>

--- a/cove/templatetags/cove_tags.py
+++ b/cove/templatetags/cove_tags.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag('modal_list.html')
+def cove_modal_list(**kw):
+    return kw

--- a/cove/views.py
+++ b/cove/views.py
@@ -47,7 +47,7 @@ def uniqueIds(validator, uI, instance, schema):
                 return
 
         if non_unique_ids:
-            yield ValidationError("Non-unique Id Values {}".format(", ".join(non_unique_ids)))
+            yield ValidationError("Non-unique ID Values (first 3 shown):  {}".format(", ".join(list(non_unique_ids)[:3])))
 
 
 validator.VALIDATORS.pop("patternProperties")
@@ -111,22 +111,66 @@ def get_records_aggregates(json_data):
 
 
 def get_grants_aggregates(json_data):
-    count = len(json_data['grants']) if 'grants' in json_data else 0
     
-    ids = []
-    unique_ids = []
+    id_count = 0
+    count = 0
+    unique_ids = set()
+    duplicate_ids = set()
+    max_award_date = ""
+    min_award_date = ""
+    max_amount_awarded = 0
+    min_amount_awarded = 0
+    distinct_funding_org_identifier = set()
+    distinct_recipient_org_identifier = set()
+    distinct_currency = set()
+
     if 'grants' in json_data:
         for grant in json_data['grants']:
-            # Gather all the ocids
-            if 'id' in grant:
-                ids.append(grant['id'])
-            
-        # Find unique ocid's
-        unique_ids = set(ids)
-    
+            count = count + 1
+            amountAwarded = grant.get('amountAwarded')
+            if amountAwarded:
+                max_amount_awarded = max(amountAwarded, max_amount_awarded)
+                if not min_amount_awarded:
+                    min_amount_awarded = amountAwarded
+                min_amount_awarded = min(amountAwarded, min_amount_awarded)
+            awardDate = grant.get('awardDate')
+            if awardDate:
+                max_award_date = max(awardDate, max_award_date)
+                if not min_award_date:
+                    min_award_date = awardDate
+                min_award_date = min(awardDate, min_award_date)
+            grant_id = grant.get('id')
+            if grant_id:
+                id_count = id_count + 1
+                if grant_id in unique_ids:
+                    duplicate_ids.add(grant_id)
+                unique_ids.add(grant_id)
+            funding_orgs = grant.get('fundingOrganization', [])
+            for funding_org in funding_orgs:
+                funding_org_id = funding_org.get('id')
+                if funding_org_id:
+                    distinct_funding_org_identifier.add(funding_org_id)
+            recipient_orgs = grant.get('recipientOrganization', [])
+            for recipient_org in recipient_orgs:
+                recipient_org_id = recipient_org.get('id')
+                if recipient_org_id:
+                    distinct_recipient_org_identifier.add(recipient_org_id)
+            currency = grant.get('currency')
+            if currency:
+                distinct_currency.add(currency)
+
     return {
         'count': count,
-        'unique_ids': unique_ids
+        'id_count': id_count,
+        'unique_ids': unique_ids,
+        'duplicate_ids': duplicate_ids,
+        'max_award_date': max_award_date,
+        'min_award_date': min_award_date,
+        'max_amount_awarded': max_amount_awarded,
+        'min_amount_awarded': min_amount_awarded,
+        'distinct_funding_org_identifier': distinct_funding_org_identifier,
+        'distinct_recipient_org_identifier': distinct_recipient_org_identifier,
+        'distinct_currency': distinct_currency
     }
 
 

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -151,7 +151,7 @@ def test_accordion(server_url, browser, prefix):
     # But we expect to see an error message if a file is not well formed JSON at all
     ('/ocds/', 'tenders_releases_2_releases_not_json.json', 'not well formed JSON', False),
     ('/ocds/', 'tenders_releases_2_releases.xlsx', 'Download Files', True),
-    ('/360/', 'WellcomeTrust-grants_fixed_2_grants.json', ['Download Files', 'Save or Share these results'], True),
+    ('/360/', 'WellcomeTrust-grants_fixed_2_grants.json', ['Download Files', 'Save or Share these results', 'Unique Grant IDs: 2', 'Duplicate IDs: 2'], True),
     # Test a 360 spreadsheet with titles, rather than fields
     ('/360/', 'WellcomeTrust-grants_2_grants.xlsx', 'Download Files', True),
     # Test a 360 csv in cp1252 incoding


### PR DESCRIPTION
Add key field information. This includes.

* slight refactoring of explore templates giving the standard specific templates more of the page
* Add modals for lists so that long lists can be displayed
* Change fixtures so that show more errors
* Add more grant aggregates