### PR TITLE
[#211] Update requirements and tell requires.io we don't want Django 1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-Django==1.8.7
+Django==1.8.7 # rq.filter: <1.9
 -e git+https://github.com/OpenDataServices/flatten-tool.git@e0ecec379a1e313666da7a5f1e511b8ca6cd0d0c#egg=flattentool
 django-bootstrap3==6.2.2
 django-debug-toolbar==1.4
-requests==2.8.1
-dealer==2.0.4
+requests==2.9.0
+dealer==2.0.5
 django-environ==0.4.0
 jsonschema==2.5.1
-raven==5.8.1
+raven==5.9.2
 strict-rfc3339==0.6
 
 # Dependencies of flatten-tool

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt 
 
 # flake8 and dependencies
-flake8==2.5.0
+flake8==2.5.1
 mccabe==0.3.1
 # Flake8 2.4.1 uses pep8 < 1.6, see
 # https://gitlab.com/pycqa/flake8/blob/ea628fa9d16b3adc6e15e6726439128d345d80d4/CHANGES.rst
@@ -9,12 +9,12 @@ pep8==1.5.7 # rq.filter: <1.6
 pyflakes==1.0.0
 
 # pytest and plugins
-py==1.4.30
-pytest==2.8.2
+py==1.4.31
+pytest==2.8.5
 pytest-django==2.9.1
 pytest-cov==2.2.0
 cov-core==1.15.0
-coverage==4.0.2
+coverage==4.0.3
 pytest-localserver==0.3.4
 Werkzeug==0.11.2
 


### PR DESCRIPTION


<!---
@huboard:{"order":1.069534306494461,"milestone_order":212,"custom_state":""}
-->
