### PR TITLE
[#218] Remove $ from list of random chars.

### DIFF
--- a/cove/settings.py
+++ b/cove/settings.py
@@ -17,7 +17,7 @@ from django.utils.crypto import get_random_string
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
+chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)'
 secret_key = get_random_string(50, chars)
 if 'SECRET_KEY' not in os.environ:
     warnings.warn('SECRET_KEY should be added to Enviroment Variables. Random key will be used instead.')


### PR DESCRIPTION
This is just to make sure that the first character is not a $.  If it is
then it causes django environ to go into an infinitly recurse.  
See
https://github.com/joke2k/django-environ/issues/60