### PR TITLE
[#228] Test alternative endpoints

### DIFF
--- a/cove/settings.py
+++ b/cove/settings.py
@@ -107,9 +107,10 @@ DEBUG = env('DEBUG')
 
 ALLOWED_HOSTS = env('ALLOWED_HOSTS')
 
-RAVEN_CONFIG = {
-    'dsn': env('SENTRY_DSN')
-}
+if env('SENTRY_DSN'):
+    RAVEN_CONFIG = {
+        'dsn': env('SENTRY_DSN')
+    }
 
 
 # Application definition


### PR DESCRIPTION
Allow you to add enironment variables PREFIX_360 and PREFIX_OCDS to test
endpoints that are not in the normal locations.

There is a also a slight change to config so that if you do not put in
any SENTRY config then it does not use it.