### PR TITLE
[#250] Add missing revision

### DIFF
--- a/cove/templates/base_generic.html
+++ b/cove/templates/base_generic.html
@@ -116,7 +116,7 @@
             <li><a href="{% url 'cove:terms' %}">{% trans "Terms &amp; Conditions" %}</a></li>
           </ul>
           {% comment %}Translators: Provides information about the version of the code base that is being used{% endcomment %}
-          <p class="text-muted">{% blocktrans %}Running version {% endblocktrans %}<a href="https://github.com/OpenDataServices/cove/tree/{{version}}">{{version}}</a></p>
+          <p class="text-muted">{% blocktrans %}Running version {% endblocktrans %}<a href="https://github.com/OpenDataServices/cove/tree/{{request.tag}}">{{request.tag}}</a></p>
         </div>
         <div class="col-md-6">
           <h4>{% trans "Links" %}</h4>


### PR DESCRIPTION
using revision.tag seems to work. It will use revision number if there is not a tag.   I have no idea where version came from.