### PR TITLE
Post Feb 2016 bug fixes (3) - OCDS 1.0.1 - live deployment

### DIFF
--- a/cove/settings.py
+++ b/cove/settings.py
@@ -67,12 +67,12 @@ COVE_CONFIG_BY_NAMESPACE = {
     },
     'schema_url': {
         'cove-360': 'https://raw.githubusercontent.com/ThreeSixtyGiving/standard/master/schema/360-giving-package-schema.json',
-        'cove-ocds': {'release': 'http://ocds.open-contracting.org/standard/r/1__0__0/release-package-schema.json',
-                      'record': 'http://ocds.open-contracting.org/standard/r/1__0__0/record-package-schema.json'},
+        'cove-ocds': {'release': 'http://standard.open-contracting.org/schema/1__0__1/release-package-schema.json',
+                      'record': 'http://standard.open-contracting.org/schema/1__0__1/record-package-schema.json'},
         'default': None
     },
     'item_schema_url': {  # Schema url for an individual item e.g. a single release or grant
-        'cove-ocds': 'http://ocds.open-contracting.org/standard/r/1__0__0/release-schema.json',
+        'cove-ocds': 'http://standard.open-contracting.org/schema/1__0__1/release-schema.json',
         'cove-360': 'https://raw.githubusercontent.com/ThreeSixtyGiving/standard/master/schema/360-giving-schema.json',
         'default': None
     },


### PR DESCRIPTION
Update the ocds schema uri to 1__0__1.

Standing tasks:
- [x] Re-run translations if any text has changed
- [x] Create a new branch `release-{{YYYYMM}}` if it doesn't exist.
- [x] Deploy to a subdomain on the dev server http://release-{{YYYYMM}}.dev.cove.opendataservices.coop/ - redo this for any additional commits
- [x] Check that the correct commit has been deployed using the link in the footer http://release-{{YYYYMM}}.dev.cove.opendataservices.coop/
- [x] Run `CUSTOM_SERVER_URL=http://release-{{YYYYMM}}.dev.cove.opendataservices.coop/ py.test fts` - redo this for each redeploy to the subomdain

After merge:
- [ ] Run salt highstate on `cove-live`
- [ ] Check that the correct commit has been deployed using the link in the footer http://cove.opendataservices.coop/
- [ ] Run `CUSTOM_SERVER_URL=http://cove.opendataservices.coop/ py.test fts` on a local copy of the updated live branch
- [ ] Run salt highstate on `cove-live-ocds`
- [ ] Check that the correct commit has been deployed using the link in the footer http://release-201602.dev.cove.opendataservices.coop/
- [ ] Run `CUSTOM_SERVER_URL=http://standard.open-contracting.org PREFIX_OCDS=/validator/ py.test fts ` on a local copy of the updated live branch