### PR TITLE
[#296] Catch stats producing errors.

### DIFF
--- a/cove/fixtures/badfile.json
+++ b/cove/fixtures/badfile.json
@@ -1,0 +1,855 @@
+{
+  "uri": "tmXf6cC4QU+lwO3O73T-ZvUX4qo2GMJ0Sd",
+  "publisher": {
+    "name": "ducimus recusandae"
+  },
+  "publishedDate": "4440-04-11T01:58:02.871Z",
+  "releases": [
+    {
+      "ocid": "et et tempora eos est",
+      "id": "facere",
+      "date": "2151-08-16T13:05:41.849Z",
+      "tag": [
+        "tenderUpdate",
+        "tenderCancellation",
+        "contract",
+        "award",
+        "contractAmendment"
+      ],
+      "initiationType": "tender",
+      "buyer": "THIS SHOULD BE AN OBJECT!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+      "planning": {
+        "rationale": "hic",
+        "budget": {
+          "amount": {},
+          "uri": "zaKZeN+ANMyTZr6LEedyOO1v,QuTlfHX1Toz3c",
+          "source": "zBqhEs1Z++vPg8c7zgr4bjVsub2eN,Zfkm0AtRQ8Kz3jTG167L4k,5b9Q+rj",
+          "project": "architecto nostrum dolor et quos",
+          "description": "optio officia"
+        }
+      },
+      "awards": [
+        {
+          "id": -99440123,
+          "documents": [
+            {
+              "id": -59293102,
+              "url": "LmJl,Y1IiJPeZT8P9O,+KlpSMhvhmUMo+vd,muSwJRc9XhYEXEHOycfhDaUi6FVbDb6zDR"
+            },
+            {
+              "id": "dolorem",
+              "description": "natus nisi sit"
+            },
+            {
+              "id": -63942572,
+              "url": null,
+              "documentType": "et placeat vero",
+              "description": null
+            },
+            {
+              "id": "debitis in qui nihil",
+              "url": null,
+              "datePublished": null,
+              "description": null,
+              "format": "eveniet",
+              "documentType": "amet magnam debitis libero occaecati",
+              "language": "quia molestiae soluta omnis eaque",
+              "dateModified": null
+            }
+          ],
+          "value": {},
+          "contractPeriod": {
+            "endDate": null,
+            "startDate": null
+          },
+          "amendment": {
+            "changes": [
+              {
+                "former_value": "deserunt cumque voluptas",
+                "property": "est ut voluptatibus molestiae"
+              },
+              {
+                "property": "quia sed",
+                "former_value": {}
+              },
+              {},
+              {
+                "former_value": [],
+                "property": "error natus quae eos accusantium"
+              },
+              {
+                "property": "et voluptas iste molestiae quae",
+                "former_value": "incidunt commodi expedita"
+              }
+            ],
+            "rationale": null,
+            "date": "3255-04-14T10:07:04.417Z"
+          },
+          "status": "cancelled",
+          "description": "earum",
+          "date": null,
+          "suppliers": [
+            {
+              "contactPoint": {
+                "url": null
+              },
+              "address": {
+                "region": null,
+                "countryName": "eos recusandae aut id",
+                "streetAddress": null
+              }
+            },
+            {
+              "additionalIdentifiers": [
+                {
+                  "legalName": null,
+                  "id": "magni harum ut autem"
+                },
+                {
+                  "uri": null,
+                  "scheme": "et ut sed",
+                  "id": -97568341,
+                  "legalName": "culpa libero"
+                },
+                {
+                  "uri": "VAUgsGch0qsQ5wEMTQkep1oDtTztcCdbaadCozvDWGO+-vanRDgN6T6BNERpFczSroEy6WrthBZxVhyPyLfooVa",
+                  "legalName": "veritatis doloribus officiis ratione non",
+                  "scheme": "harum aut a"
+                }
+              ],
+              "address": {
+                "locality": null,
+                "countryName": "vel architecto",
+                "streetAddress": "qui aliquam enim"
+              },
+              "name": "rerum doloremque provident",
+              "identifier": {
+                "legalName": "animi qui assumenda",
+                "id": "ipsa alias dolorem"
+              }
+            },
+            {},
+            {
+              "address": {},
+              "additionalIdentifiers": [
+                {},
+                {
+                  "scheme": "voluptatem",
+                  "legalName": null
+                },
+                {
+                  "legalName": null,
+                  "uri": null,
+                  "id": "quia",
+                  "scheme": "aspernatur nam blanditiis hic qui"
+                },
+                {
+                  "scheme": null,
+                  "id": 16026683
+                },
+                {
+                  "uri": "W-nKEj61XKRt5CRPYxHQESd69WOrc263Ptj016Fj-k,h8H",
+                  "legalName": null
+                }
+              ],
+              "contactPoint": {
+                "telephone": null,
+                "url": null
+              }
+            }
+          ]
+        },
+        {
+          "id": 86486734,
+          "title": "itaque aut"
+        },
+        {
+          "id": -2783133,
+          "documents": [
+            {
+              "id": 66999415,
+              "format": null,
+              "title": null,
+              "dateModified": "2641-08-17T06:10:15.515Z",
+              "documentType": "temporibus ut quisquam ut",
+              "language": null
+            }
+          ],
+          "date": null,
+          "status": "pending",
+          "description": null,
+          "amendment": {},
+          "items": [
+            {
+              "id": "assumenda qui eos",
+              "classification": {}
+            },
+            {
+              "id": "atque"
+            },
+            {
+              "id": -95825829,
+              "additionalClassifications": [
+                {
+                  "description": null
+                },
+                {
+                  "uri": null,
+                  "description": null,
+                  "scheme": null,
+                  "id": 75582490
+                },
+                {
+                  "id": null,
+                  "scheme": null,
+                  "description": null
+                }
+              ],
+              "description": "porro",
+              "unit": {
+                "name": null,
+                "value": {
+                  "currency": null,
+                  "amount": 2518403.840208994
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "eligendi reiciendis sequi aut",
+          "contractPeriod": {
+            "endDate": null
+          }
+        },
+        {
+          "id": "unde quasi laudantium dolorem veniam",
+          "date": "4835-07-14T22:40:08.843Z",
+          "amendment": {
+            "changes": [
+              {},
+              {
+                "former_value": null,
+                "property": "architecto est consequatur"
+              },
+              {},
+              {
+                "property": "modi",
+                "former_value": 15728658
+              },
+              {}
+            ]
+          },
+          "documents": [
+            {
+              "id": 69082434
+            },
+            {
+              "id": "expedita quaerat sed perferendis",
+              "format": null
+            },
+            {
+              "id": "voluptate",
+              "description": "sed fuga dolores aperiam",
+              "url": "pvKf-l4QvPS",
+              "datePublished": null,
+              "language": null,
+              "dateModified": null,
+              "documentType": "error nam quidem id",
+              "format": "voluptates ullam et omnis ut",
+              "title": null
+            },
+            {
+              "id": "perspiciatis numquam",
+              "language": "laboriosam sunt recusandae laborum qui",
+              "dateModified": "4174-04-08T02:48:46.402Z"
+            }
+          ],
+          "items": [
+            {
+              "id": -95631437,
+              "additionalClassifications": [
+                {}
+              ],
+              "description": "qui explicabo doloribus",
+              "unit": {
+                "name": "sapiente praesentium sequi rerum voluptate",
+                "value": {
+                  "currency": "qui",
+                  "amount": null
+                }
+              }
+            },
+            {
+              "id": -54951176
+            },
+            {
+              "id": "soluta",
+              "classification": {},
+              "description": "itaque ut voluptatibus distinctio"
+            },
+            {
+              "id": "qui autem dolorem",
+              "quantity": null,
+              "additionalClassifications": [
+                {
+                  "scheme": "debitis",
+                  "uri": null,
+                  "description": "aut",
+                  "id": "atque nihil"
+                }
+              ],
+              "classification": {}
+            }
+          ],
+          "value": {
+            "currency": null,
+            "amount": 72196178.48101778
+          },
+          "contractPeriod": {
+            "startDate": "3439-01-18T08:13:37.925Z",
+            "endDate": "5117-08-25T12:53:32.408Z"
+          },
+          "status": "unsuccessful",
+          "title": "sit",
+          "description": null,
+          "suppliers": [
+            {
+              "additionalIdentifiers": [
+                {
+                  "id": null
+                }
+              ],
+              "name": null,
+              "identifier": {
+                "uri": null
+              },
+              "address": {
+                "countryName": null,
+                "postalCode": "maxime voluptatibus deleniti"
+              },
+              "contactPoint": {
+                "name": null
+              }
+            },
+            {
+              "additionalIdentifiers": [
+                {
+                  "id": 76236539,
+                  "scheme": null,
+                  "legalName": null
+                },
+                {},
+                {
+                  "uri": "sV,PG",
+                  "scheme": null,
+                  "id": -24927620,
+                  "legalName": null
+                }
+              ],
+              "identifier": {},
+              "name": "et et",
+              "address": {
+                "locality": "distinctio quisquam",
+                "postalCode": "reprehenderit animi sed itaque"
+              },
+              "contactPoint": {
+                "telephone": "id reprehenderit",
+                "name": "iusto illum commodi nemo sed",
+                "email": null,
+                "url": null
+              }
+            },
+            {
+              "name": null,
+              "additionalIdentifiers": [
+                {},
+                {
+                  "id": null,
+                  "uri": null,
+                  "legalName": "ratione id laudantium harum"
+                },
+                {
+                  "scheme": "dolore est a sit",
+                  "uri": "OEEeP+R3F3e-CqSCca9u,mSH5nPFcbOBXFXH+LC+zNN6en6GIl+oSVa7UM-0wImR9+",
+                  "legalName": null
+                },
+                {
+                  "id": -54185744,
+                  "uri": null,
+                  "scheme": "placeat",
+                  "legalName": null
+                },
+                {
+                  "legalName": "perferendis optio ratione",
+                  "uri": null
+                }
+              ],
+              "address": {},
+              "contactPoint": {
+                "email": null,
+                "url": "ku9gWvo5k,VA-2V.Jh1ay1jdY",
+                "faxNumber": null,
+                "name": "accusamus eveniet dolor sit"
+              },
+              "identifier": {
+                "id": 30324093
+              }
+            }
+          ]
+        }
+      ],
+      "language": "et quia ea impedit",
+      "contracts": [
+        {
+          "id": -28632151,
+          "awardID": "aliquid",
+          "title": null,
+          "period": {},
+          "value": {
+            "currency": null,
+            "amount": null
+          },
+          "items": [
+            {
+              "id": -48867566,
+              "quantity": 80087752,
+              "unit": {
+                "value": {
+                  "amount": 91965103.19954532,
+                  "currency": "accusamus"
+                },
+                "name": "deserunt vel beatae velit consequatur"
+              },
+              "classification": {
+                "scheme": null
+              }
+            },
+            {
+              "id": "ducimus sequi"
+            }
+          ],
+          "documents": [
+            {
+              "id": "sit aut aut sequi",
+              "datePublished": null,
+              "url": "T9p7MHWqmuzxVWaTiX",
+              "format": null,
+              "description": null,
+              "title": "ut",
+              "language": "ut quo id nihil eos",
+              "documentType": "necessitatibus",
+              "dateModified": null
+            },
+            {
+              "id": "distinctio",
+              "language": "doloremque nobis placeat"
+            }
+          ],
+          "description": "eligendi sint placeat"
+        },
+        {
+          "id": "et distinctio aut",
+          "awardID": 20395685,
+          "period": {
+            "startDate": null,
+            "endDate": null
+          },
+          "description": null,
+          "status": "cancelled",
+          "amendment": {
+            "rationale": "aut sint et dolore voluptatem",
+            "date": "2284-12-14T13:38:35.860Z"
+          },
+          "items": [
+            {
+              "id": -81601581,
+              "additionalClassifications": [
+                {
+                  "id": null,
+                  "uri": null,
+                  "scheme": null,
+                  "description": "est qui minus"
+                },
+                {
+                  "uri": "p2UreL5.i5I5Dnkb",
+                  "description": "non sapiente voluptatem"
+                },
+                {
+                  "uri": null
+                },
+                {
+                  "uri": null,
+                  "scheme": "sunt facilis tempore quo consequatur",
+                  "description": "maiores est vero"
+                },
+                {
+                  "uri": "DBfuvsF0zk14tp049Z"
+                }
+              ]
+            },
+            {
+              "id": "voluptatem cum"
+            },
+            {
+              "id": 54974964,
+              "unit": {
+                "value": {
+                  "currency": "dignissimos autem sit eos"
+                }
+              },
+              "description": "sequi magnam dolorum et",
+              "quantity": null,
+              "classification": {
+                "description": null,
+                "uri": "mO7zTGY+Y.TLfTDKUjdSXrbeNGnDd.TF8dD502T1Qt+S+NgOAUlEAkJoatKtUP,qgQ",
+                "id": "fuga",
+                "scheme": null
+              },
+              "additionalClassifications": [
+                {
+                  "description": null,
+                  "uri": "p3tKXWOuZrryPuBY2B,bCFnTHT8N4-jw7g6NRMi",
+                  "scheme": null,
+                  "id": null
+                },
+                {},
+                {
+                  "uri": null,
+                  "id": 73225268,
+                  "scheme": null,
+                  "description": "enim inventore esse"
+                },
+                {
+                  "scheme": "reiciendis nesciunt ut"
+                },
+                {
+                  "description": "nobis quia dolores enim nulla",
+                  "scheme": null,
+                  "id": -28433813,
+                  "uri": null
+                }
+              ]
+            }
+          ],
+          "implementation": {
+            "milestones": [
+              {
+                "id": -35115048,
+                "dueDate": "5107-11-04T07:43:51.268Z",
+                "documents": [
+                  {
+                    "id": "aliquid est sit",
+                    "datePublished": null,
+                    "title": null,
+                    "dateModified": null,
+                    "description": null,
+                    "documentType": null,
+                    "language": null,
+                    "format": "odio",
+                    "url": null
+                  }
+                ],
+                "status": "notMet",
+                "dateModified": null,
+                "title": null
+              },
+              {
+                "id": "sed"
+              }
+            ]
+          }
+        },
+        {
+          "id": "et eum dolor explicabo",
+          "awardID": 53647781
+        },
+        {
+          "id": -3532710,
+          "awardID": "dolorem perferendis est nulla tempore",
+          "status": "cancelled",
+          "value": {
+            "amount": null,
+            "currency": null
+          },
+          "documents": [
+            {
+              "id": "sit facere quos"
+            },
+            {
+              "id": "iure nemo laboriosam et et",
+              "title": "accusamus",
+              "documentType": null,
+              "format": "laborum voluptatem",
+              "dateModified": "4450-05-02T06:23:17.898Z",
+              "language": "id omnis",
+              "url": "t0O8BqsM8DKTN7CmdtfOG6",
+              "datePublished": null,
+              "description": "porro nostrum inventore officia quo"
+            }
+          ],
+          "implementation": {
+            "milestones": [
+              {
+                "id": 5003559
+              },
+              {
+                "id": "vero vel dicta",
+                "documents": [
+                  {
+                    "id": 6597202
+                  },
+                  {
+                    "id": -40611149,
+                    "documentType": null,
+                    "dateModified": null,
+                    "datePublished": "4134-02-22T14:33:58.821Z",
+                    "url": null,
+                    "language": null
+                  },
+                  {
+                    "id": "iure dolores",
+                    "title": "rerum soluta itaque incidunt",
+                    "format": null,
+                    "description": "tempora sint sunt et mollitia"
+                  }
+                ]
+              },
+              {
+                "id": "aut quas",
+                "status": "partiallyMet",
+                "dateModified": null,
+                "description": null,
+                "title": null,
+                "documents": [
+                  {
+                    "id": -74576830,
+                    "datePublished": null,
+                    "language": "voluptas facere labore reprehenderit adipisci",
+                    "title": "aut voluptates"
+                  },
+                  {
+                    "id": -99262119,
+                    "documentType": null,
+                    "description": null,
+                    "title": null,
+                    "url": null,
+                    "datePublished": null
+                  },
+                  {
+                    "id": "consectetur et quia maxime voluptas",
+                    "title": "dolor eos ipsum",
+                    "description": "vel repellendus",
+                    "language": "dolore"
+                  }
+                ]
+              }
+            ],
+            "documents": [
+              {
+                "id": 41717088,
+                "format": "ab enim repellendus placeat",
+                "datePublished": null,
+                "dateModified": "3329-05-13T17:48:36.584Z",
+                "description": null,
+                "title": null,
+                "language": "et"
+              },
+              {
+                "id": "et reiciendis saepe",
+                "documentType": null,
+                "url": "T93APz,x3v..SvSJNbIQPvukFKyCvObNCaRcS6tv-C+ZVi.Hb--vvrdqNJPiAG.13nU7u22GUFO0p.WUIc,T-1xhdd7S",
+                "title": null,
+                "datePublished": null,
+                "dateModified": "4360-10-19T15:07:50.173Z"
+              },
+              {
+                "id": "est"
+              }
+            ],
+            "transactions": [
+              {
+                "id": "et et natus",
+                "uri": null,
+                "date": null
+              },
+              {
+                "id": "iusto alias qui",
+                "uri": null
+              }
+            ]
+          }
+        }
+      ],
+      "tender": {
+        "id": "dolores",
+        "submissionMethod": null,
+        "status": "complete",
+        "tenderers": [
+          {}
+        ],
+        "numberOfTenderers": null,
+        "description": "deleniti itaque voluptatum quas",
+        "enquiryPeriod": {
+          "startDate": null
+        },
+        "submissionMethodDetails": "iure beatae rerum necessitatibus aut",
+        "awardCriteriaDetails": "molestiae id",
+        "awardPeriod": {
+          "startDate": null
+        },
+        "items": [
+          {
+            "id": "suscipit dolor in",
+            "classification": {},
+            "additionalClassifications": [
+              {
+                "uri": null,
+                "description": "sapiente",
+                "id": "adipisci ut eum quas soluta"
+              },
+              {
+                "scheme": null
+              },
+              {},
+              {
+                "uri": null,
+                "description": "rem et",
+                "scheme": "libero provident voluptas"
+              }
+            ]
+          },
+          {
+            "id": -95512785,
+            "description": null,
+            "quantity": null,
+            "additionalClassifications": [
+              {},
+              {
+                "uri": null
+              },
+              {
+                "scheme": "rerum hic dolor nihil",
+                "id": 47885014,
+                "description": "laboriosam qui necessitatibus"
+              },
+              {
+                "description": "ab provident reiciendis sunt eos"
+              }
+            ],
+            "classification": {
+              "description": null,
+              "id": 54545556,
+              "uri": "vDhMoHwK,WrSfUI6EHwCnIbwWIqcZg0h1YtQD+",
+              "scheme": null
+            },
+            "unit": {
+              "name": "molestiae aut magnam quasi"
+            }
+          }
+        ],
+        "milestones": [
+          {
+            "id": -44096437,
+            "description": null
+          },
+          {
+            "id": 20730203,
+            "dateModified": "4427-11-13T21:58:39.610Z",
+            "description": "dicta eos",
+            "documents": [
+              {
+                "id": "eos a quidem aliquam omnis",
+                "title": null,
+                "documentType": "eum illum itaque est consequuntur",
+                "datePublished": null,
+                "language": "ut voluptatum sint velit",
+                "dateModified": "2464-06-06T00:38:05.291Z",
+                "format": "aut at",
+                "description": null
+              },
+              {
+                "id": "aut illum iusto corrupti quia",
+                "description": null,
+                "url": null,
+                "dateModified": "2025-02-28T19:03:33.299Z",
+                "datePublished": null,
+                "documentType": "et nihil perspiciatis eius",
+                "title": "aperiam",
+                "language": "aut aut"
+              },
+              {
+                "id": "dolorem porro non quisquam",
+                "url": "C3a9m5IdYig+OO9UuDeOGs+A2Xbmgt8TxfF455wlnOom+d2HxxdEDZRhWvQQzPtXhmc",
+                "dateModified": "3320-09-03T01:28:56.967Z",
+                "title": null,
+                "datePublished": "2814-03-07T05:49:34.581Z",
+                "format": "magni sit laborum",
+                "description": "doloribus",
+                "documentType": "in qui"
+              }
+            ],
+            "title": "eaque",
+            "dueDate": "5026-03-30T17:43:12.398Z"
+          },
+          {
+            "id": 28847320,
+            "description": null,
+            "dueDate": "3773-09-19T18:57:30.390Z",
+            "documents": [
+              {
+                "id": "eos est",
+                "datePublished": null,
+                "format": null,
+                "url": null,
+                "title": "eius ea",
+                "documentType": null,
+                "language": null,
+                "dateModified": null
+              },
+              {
+                "id": 19336423,
+                "datePublished": "2036-09-09T18:46:59.278Z",
+                "description": null,
+                "title": null,
+                "dateModified": null,
+                "documentType": "consequatur esse",
+                "language": null,
+                "url": "X2",
+                "format": null
+              },
+              {
+                "id": "sed",
+                "datePublished": null,
+                "format": "dignissimos"
+              },
+              {
+                "id": "repudiandae quidem et quaerat neque",
+                "url": null,
+                "datePublished": null,
+                "dateModified": null,
+                "documentType": "est dolorem repellendus explicabo"
+              }
+            ]
+          }
+        ],
+        "minValue": {},
+        "procurementMethod": "open",
+        "procuringEntity": {
+          "name": null
+        },
+        "value": {
+          "amount": null
+        },
+        "procurementMethodRationale": null,
+        "eligibilityCriteria": null,
+        "amendment": {},
+        "awardCriteria": null,
+        "title": null,
+        "hasEnquiries": true
+      }
+    }
+  ],
+  "license": "x2x,fLBCpWkl4NzF+CxC32mSVweGlN94CR2-k-hNU9L1ZWnMM9C8rxvfvA42VpsaF5C5Mb,d",
+  "publicationPolicy": "qulrNGCvYJPH3zG8B.W7O.DfO33xjF1nyAk0TI027jowklrB,0"
+}

--- a/cove/templates/explore_ocds-release.html
+++ b/cove/templates/explore_ocds-release.html
@@ -42,6 +42,8 @@
   </div>
 
 </div><!--End Row -->
+
+{% if ra %}
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-primary">
@@ -254,7 +256,18 @@
     </div>
   </div>
 </div><!--End Row -->
+{% else %}
+<div class="row"> <!--Start Row (Detail Table)-->
+  <div class="col-xs-12">
+    <div class="alert alert-danger">
+      {%blocktrans%}Statistics can not produced as data is invalid.{%endblocktrans%}
+    </div>
+  </div>
+</div>
+{% endif %}
+
 {% endwith %}
+
 
 <div class="row"> <!--Start Row (Detail Table)-->
   <div class="col-md-12">

--- a/cove/tests.py
+++ b/cove/tests.py
@@ -221,6 +221,13 @@ def test_get_releases_aggregates():
 
     assert actual_cleaned == EXPECTED_RELEASE_AGGREGATE_RANDOM
 
+    with open(os.path.join('cove', 'fixtures', 'badfile.json')) as fp:
+        data = json.load(fp)
+
+    actual = v.get_releases_aggregates(data, ignore_errors=True)
+
+    assert actual == {}
+
 
 def test_fields_present():
     assert v.get_fields_present({}) == {}

--- a/cove/views.py
+++ b/cove/views.py
@@ -41,7 +41,7 @@ def uniqueIds(validator, uI, instance, schema):
             except AttributeError:
                 ##if item is not a dict
                 item_id = None
-            if item_id:
+            if item_id and not isinstance(item_id, list):
                 if item_id in all_ids:
                     non_unique_ids.add(item_id)
                 all_ids.add(item_id)
@@ -83,6 +83,19 @@ def update_docs(document_parent, counter):
     return count
 
 
+def ignore_errors(f):
+    def ignore(json_data, ignore_errors=False):
+        if ignore_errors:
+            try:
+                return f(json_data)
+            except (KeyError, TypeError, IndexError, AttributeError):
+                return {}
+        else:
+            return f(json_data)
+    return ignore
+
+
+@ignore_errors
 def get_releases_aggregates(json_data):
     release_count = 0
     unique_ocids = set()
@@ -420,6 +433,7 @@ def get_releases_aggregates(json_data):
     )
 
 
+@ignore_errors
 def get_records_aggregates(json_data):
     # Unique ocids
     unique_ocids = set()
@@ -439,6 +453,7 @@ def get_records_aggregates(json_data):
     }
 
 
+@ignore_errors
 def get_grants_aggregates(json_data):
 
     id_count = 0
@@ -826,7 +841,7 @@ def explore(request, pk):
             context['records_aggregates'] = get_records_aggregates(json_data)
             view = 'explore_ocds-record.html'
         else:
-            context['releases_aggregates'] = get_releases_aggregates(json_data)
+            context['releases_aggregates'] = get_releases_aggregates(json_data, ignore_errors=bool(validation_errors))
             view = 'explore_ocds-release.html'
     elif request.current_app == 'cove-360':
         context['grants_aggregates'] = get_grants_aggregates(json_data)

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -51,8 +51,7 @@ def test_index_page(server_url, browser):
 
 
 @pytest.mark.parametrize(('link_text', 'expected_text', 'css_selector', 'url'), [
-    # FIXME: Pick some text to lookg for on the OCP home page. Currently it's changing a lot.
-    ('Open Contracting', '', 'div.homepage-title h1', 'http://www.open-contracting.org/'),
+    ('Open Contracting', 'We connect governments', 'h1', 'http://www.open-contracting.org/'),
     ('Open Contracting Data Standard', 'Open Contracting Data Standard: Documentation', '#open-contracting-data-standard-documentation', 'http://standard.open-contracting.org/'),
     ])
 def test_footer_ocds(server_url, browser, link_text, expected_text, css_selector, url):
@@ -180,6 +179,7 @@ def test_accordion(server_url, browser, prefix):
     # But we expect to see an error message if a file is not well formed JSON at all
     (PREFIX_OCDS, 'tenders_releases_2_releases_not_json.json', 'not well formed JSON', False),
     (PREFIX_OCDS, 'tenders_releases_2_releases.xlsx', 'Download Files', True),
+    (PREFIX_OCDS, 'badfile.json', 'Statistics can not produced', True),
     (PREFIX_360, 'WellcomeTrust-grants_fixed_2_grants.json', ['Download Files',
                                                            'Save or Share these results',
                                                            'Unique Grant IDs: 2',


### PR DESCRIPTION
Catch all main errors caused when decending json objects and do not
show stats if this is the case.  Give warning to user saying this.

Errors will still be raised if the data passes validation but
there is an error in the stats code. So basically we do a good attempt
at producing stats for invalid data but only if the data is close
to being valid.