### PR TITLE
[#235] Turns text into useful OCDS links

### DIFF
--- a/cove/templates/base_ocds.html
+++ b/cove/templates/base_ocds.html
@@ -81,13 +81,13 @@
 {% endblock %}
 
 {% block introduction %}
-<div class="row">
+<div class="row" id="introduction">
   <div class="col-sm-6">
     <div class="panel panel-default">
       <div class="panel-body">
 
         <h1 class="heading-in-panel"> <small> {% blocktrans %}About OCDS {%endblocktrans%}</small> </h1>
-        <p> {% blocktrans %}The Open Contracting Data Standard (OCDS) exists to formalize how contracting data and documents can be published in an accessible, structured and repeatable way.{%endblocktrans%} </p>
+        <p> {% blocktrans %}The <a href="http://standard.open-contracting.org/">Open Contracting Data Standard (OCDS)</a> exists to formalize how contracting data and documents can be published in an accessible, structured and repeatable way.{%endblocktrans%} </p>
         <p> {% blocktrans %}Governments around the world spend an estimated US$9.5 trillion through contracts every year. Yet, contracting information is often unavailable for public scrutiny. OCDS works to change that.{%endblocktrans%} </p>
       </div>
     </div>
@@ -99,7 +99,7 @@
         <h1 class="heading-in-panel"> <small>{% blocktrans %}Validate and Explore{%endblocktrans%}</small> </h1>
         <p> {% blocktrans %}This tool helps you to:{%endblocktrans%} </p>
         <ul>
-          <li> {% blocktrans %}Check that your OCDS data complies with the schema{%endblocktrans%}</li>
+          <li> {% blocktrans %}Check that your OCDS data complies with the <a href="http://standard.open-contracting.org/latest/en/schema/">schema</a>{%endblocktrans%}</li>
           <li> {% blocktrans %}Inspect key contents of your data to check data quality{%endblocktrans%} </li>
           <li> {% blocktrans %}Access your data in different formats (spreadsheet and JSON) to support further data validation.{%endblocktrans%} </li>
           </br>
@@ -111,19 +111,19 @@
 {% endblock %}
 
 {% block howToUse %}
-<div class="row">
+<div class="row" id="how-to-use">
   <div class="col-xs-12">
     <div class="panel panel-default">
       <div class="panel-body">
 
         <h1 class="heading-in-panel"> <small> {% blocktrans %}Using the validator{%endblocktrans%}</small> </h1>
-        <p> {% blocktrans %}You can upload, paste or provide a link to data published using the Open Contracting Data Standard. This can be:{%endblocktrans%} </p>
+        <p> {% blocktrans %}You can upload, paste or provide a link to data published using the <a href="http://standard.open-contracting.org/">Open Contracting Data Standard</a>. This can be:{%endblocktrans%} </p>
 
         <ul>
           <li> {% blocktrans %}<b> JSON </b> - following the OCDS schema; {%endblocktrans%}</li>
-          <li> {% blocktrans %}<b> A CSV file or Excel Spreadsheet </b> - using the flattened serialization of OCDS; {%endblocktrans%}</li>
+          <li> {% blocktrans %}<b> A CSV file or Excel Spreadsheet </b> - using the <a href="http://standard.open-contracting.org/latest/en/implementation/serialization/">flattened serialization of OCDS</a>; {%endblocktrans%}</li>
         </ul>
-        <p> {% blocktrans %}The application works with both 'release' and 'record' OCDS documents that conform to the Open Data Contracting Standard {%endblocktrans%} </p>
+        <p> {% blocktrans %}The application works with both <a href="http://standard.open-contracting.org/latest/en/getting_started/releases_and_records/">'release' and 'record'</a> OCDS documents that conform to the <a href="http://standard.open-contracting.org/">Open Data Contracting Standard</a> {%endblocktrans%} </p>
         <p> {% blocktrans %}If your data passes basic validation checks, the tool will then present a report on data quality, and information about the contents of your file. It will also offer alternative copies of the data for download. {%endblocktrans%} </p>
         <p> {% blocktrans %}Data is stored for 7 days at a randomly generated URL. You can share this link with others to support discussion of data quality.  {%endblocktrans%} </p>
         <p> {% blocktrans %}To preview how the validator works, try <a href="?source_url=https://raw.githubusercontent.com/open-contracting/sample-data/master/fictional-example/ocds-213czf-000-00001-02-tender.json"> loading some sample data. </a>{% endblocktrans%} </p>

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -58,7 +58,8 @@ def test_footer_ocds(server_url, browser, link_text, expected_text, css_selector
     if not PREFIX_OCDS:
         return
     browser.get(server_url + PREFIX_OCDS)
-    link = browser.find_element_by_link_text(link_text)
+    footer = browser.find_element_by_id('footer')
+    link = footer.find_element_by_link_text(link_text)
     href = link.get_attribute("href")
     assert url in href
     link.click()
@@ -90,6 +91,22 @@ def test_index_page_ocds(server_url, browser):
     assert 'Using the validator' in browser.find_element_by_tag_name('body').text
     assert "'release'" in browser.find_element_by_tag_name('body').text
     assert "'record'" in browser.find_element_by_tag_name('body').text
+
+
+@pytest.mark.parametrize(('css_id', 'link_text', 'url'), [
+    ('introduction', 'schema', 'http://standard.open-contracting.org/latest/en/schema/'),
+    ('introduction', 'Open Contracting Data Standard (OCDS)', 'http://standard.open-contracting.org/'),
+    ('how-to-use', "'release' and 'record'", 'http://standard.open-contracting.org/latest/en/getting_started/releases_and_records/'),
+    ('how-to-use', 'flattened serialization of OCDS', 'http://standard.open-contracting.org/latest/en/implementation/serialization/'),
+    ('how-to-use', 'Open Contracting Data Standard', 'http://standard.open-contracting.org/')
+    ])
+def test_index_page_ocds_links(server_url, browser, css_id, link_text, url):
+    if not PREFIX_OCDS:
+        return
+    section = browser.find_element_by_id(css_id)
+    link = section.find_element_by_link_text(link_text)
+    href = link.get_attribute("href")
+    assert url in href
     
     
 def test_index_page_360(server_url, browser):


### PR DESCRIPTION
On the OCDS 'welcome' page there are many opportunities to link to the
standard, schema etc. This makes those links.
Also adds tests for those links and refactors existing tests to deal
with conflicts where the tests pick the first instance of multiple links