### PR TITLE
Post March 2016 fixes (1) - fix null tag 500 error - live deployment 

### DIFF
--- a/cove/fixtures/SOURCES
+++ b/cove/fixtures/SOURCES
@@ -27,3 +27,6 @@ License: Creative Commons Attribution
 paul-hamlyn-foundation-grants_dc.txt
 Source: Edited version of data taken from http://data.threesixtygiving.org/sites/default/files/PHF-201314grants_1.csv
 License: Creative Commons Attribution
+
+ocds_release_nulls.json
+Adapted from://github.com/open-contracting/sample-data/blob/master/blank-template/release-template-1__0__0.json 

--- a/cove/fixtures/ocds_release_nulls.json
+++ b/cove/fixtures/ocds_release_nulls.json
@@ -1,0 +1,457 @@
+{ "releases": [{
+    "ocid": null,
+    "id": null,
+    "date": null,
+    "tag": null,
+    "initiationType": null,
+    "planning": {
+        "budget": {
+            "source": null,
+            "id": null,
+            "description": null,
+            "amount": {
+                "amount": null,
+                "currency": null
+            },
+            "project": null,
+            "projectID": null,
+            "uri": null
+        },
+        "rationale": null,
+        "documents": [
+            {
+                "id": null,
+                "documentType": null,
+                "title": null,
+                "description": null,
+                "url": null,
+                "datePublished": null,
+                "dateModified": null,
+                "format": null,
+                "language": null
+            }
+        ]
+    },
+    "tender": {
+        "id": null,
+        "title": null,
+        "description": null,
+        "status": null,
+        "items": [
+            {
+                "id": null,
+                "description": null,
+                "classification": {
+                    "scheme": null,
+                    "id": null,
+                    "description": null,
+                    "uri": null
+                },
+                "additionalClassifications": [
+                    {
+                        "scheme": null,
+                        "id": null,
+                        "description": null,
+                        "uri": null
+                    }
+                ],
+                "quantity": null,
+                "unit": {
+                    "name": null,
+                    "value": {
+                        "amount": null,
+                        "currency": null
+                    }
+                }
+            }
+        ],
+        "minValue": {
+            "amount": null,
+            "currency": null
+        },
+        "value": {
+            "amount": null,
+            "currency": null
+        },
+        "procurementMethod": null,
+        "procurementMethodRationale": null,
+        "awardCriteria": null,
+        "awardCriteriaDetails": null,
+        "submissionMethod": null,
+        "submissionMethodDetails": null,
+        "tenderPeriod": {
+            "startDate": null,
+            "endDate": null
+        },
+        "enquiryPeriod": {
+            "startDate": null,
+            "endDate": null
+        },
+        "hasEnquiries": null,
+        "eligibilityCriteria": null,
+        "awardPeriod": {
+            "startDate": null,
+            "endDate": null
+        },
+        "numberOfTenderers": null,
+        "tenderers": [
+            {
+                "identifier": {
+                    "scheme": null,
+                    "id": null,
+                    "legalName": null,
+                    "uri": null
+                },
+                "additionalIdentifiers": [
+                    {
+                        "scheme": null,
+                        "id": null,
+                        "legalName": null,
+                        "uri": null
+                    }
+                ],
+                "name": null,
+                "address": {
+                    "streetAddress": null,
+                    "locality": null,
+                    "region": null,
+                    "postalCode": null,
+                    "countryName": null
+                },
+                "contactPoint": {
+                    "name": null,
+                    "email": null,
+                    "telephone": null,
+                    "faxNumber": null,
+                    "url": null
+                }
+            }
+        ],
+        "procuringEntity": {
+            "identifier": {
+                "scheme": null,
+                "id": null,
+                "legalName": null,
+                "uri": null
+            },
+            "additionalIdentifiers": [
+                {
+                    "scheme": null,
+                    "id": null,
+                    "legalName": null,
+                    "uri": null
+                }
+            ],
+            "name": null,
+            "address": {
+                "streetAddress": null,
+                "locality": null,
+                "region": null,
+                "postalCode": null,
+                "countryName": null
+            },
+            "contactPoint": {
+                "name": null,
+                "email": null,
+                "telephone": null,
+                "faxNumber": null,
+                "url": null
+            }
+        },
+        "documents": [
+            {
+                "id": null,
+                "documentType": null,
+                "title": null,
+                "description": null,
+                "url": null,
+                "datePublished": null,
+                "dateModified": null,
+                "format": null,
+                "language": null
+            }
+        ],
+        "milestones": [
+            {
+                "id": null,
+                "title": null,
+                "description": null,
+                "dueDate": null,
+                "dateModified": null,
+                "status": null,
+                "documents": [
+                    {
+                        "id": null,
+                        "documentType": null,
+                        "title": null,
+                        "description": null,
+                        "url": null,
+                        "datePublished": null,
+                        "dateModified": null,
+                        "format": null,
+                        "language": null
+                    }
+                ]
+            }
+        ],
+        "amendment": {
+            "date": null,
+            "changes": null,
+            "rationale": null
+        }
+    },
+    "buyer": {
+        "identifier": {
+            "scheme": null,
+            "id": null,
+            "legalName": null,
+            "uri": null
+        },
+        "additionalIdentifiers": [
+            {
+                "scheme": null,
+                "id": null,
+                "legalName": null,
+                "uri": null
+            }
+        ],
+        "name": null,
+        "address": {
+            "streetAddress": null,
+            "locality": null,
+            "region": null,
+            "postalCode": null,
+            "countryName": null
+        },
+        "contactPoint": {
+            "name": null,
+            "email": null,
+            "telephone": null,
+            "faxNumber": null,
+            "url": null
+        }
+    },
+    "awards": [
+        {
+            "id": null,
+            "title": null,
+            "description": null,
+            "status": null,
+            "date": null,
+            "value": {
+                "amount": null,
+                "currency": null
+            },
+            "suppliers": [
+                {
+                    "identifier": {
+                        "scheme": null,
+                        "id": null,
+                        "legalName": null,
+                        "uri": null
+                    },
+                    "additionalIdentifiers": [
+                        {
+                            "scheme": null,
+                            "id": null,
+                            "legalName": null,
+                            "uri": null
+                        }
+                    ],
+                    "name": null,
+                    "address": {
+                        "streetAddress": null,
+                        "locality": null,
+                        "region": null,
+                        "postalCode": null,
+                        "countryName": null
+                    },
+                    "contactPoint": {
+                        "name": null,
+                        "email": null,
+                        "telephone": null,
+                        "faxNumber": null,
+                        "url": null
+                    }
+                }
+            ],
+            "items": [
+                {
+                    "id": null,
+                    "description": null,
+                    "classification": {
+                        "scheme": null,
+                        "id": null,
+                        "description": null,
+                        "uri": null
+                    },
+                    "additionalClassifications": [
+                        {
+                            "scheme": null,
+                            "id": null,
+                            "description": null,
+                            "uri": null
+                        }
+                    ],
+                    "quantity": null,
+                    "unit": {
+                        "name": null,
+                        "value": {
+                            "amount": null,
+                            "currency": null
+                        }
+                    }
+                }
+            ],
+            "contractPeriod": {
+                "startDate": null,
+                "endDate": null
+            },
+            "documents": [
+                {
+                    "id": null,
+                    "documentType": null,
+                    "title": null,
+                    "description": null,
+                    "url": null,
+                    "datePublished": null,
+                    "dateModified": null,
+                    "format": null,
+                    "language": null
+                }
+            ],
+            "amendment": {
+                "date": null,
+                "changes": null,
+                "rationale": null
+            }
+        }
+    ],
+    "contracts": [
+        {
+            "id": null,
+            "awardID": null,
+            "title": null,
+            "description": null,
+            "status": null,
+            "period": {
+                "startDate": null,
+                "endDate": null
+            },
+            "value": {
+                "amount": null,
+                "currency": null
+            },
+            "items": [
+                {
+                    "id": null,
+                    "description": null,
+                    "classification": {
+                        "scheme": null,
+                        "id": null,
+                        "description": null,
+                        "uri": null
+                    },
+                    "additionalClassifications": [
+                        {
+                            "scheme": null,
+                            "id": null,
+                            "description": null,
+                            "uri": null
+                        }
+                    ],
+                    "quantity": null,
+                    "unit": {
+                        "name": null,
+                        "value": {
+                            "amount": null,
+                            "currency": null
+                        }
+                    }
+                }
+            ],
+            "dateSigned": null,
+            "documents": [
+                {
+                    "id": null,
+                    "documentType": null,
+                    "title": null,
+                    "description": null,
+                    "url": null,
+                    "datePublished": null,
+                    "dateModified": null,
+                    "format": null,
+                    "language": null
+                }
+            ],
+            "amendment": {
+                "date": null,
+                "changes": null,
+                "rationale": null
+            },
+            "implementation": {
+                "transactions": [
+                    {
+                        "id": null,
+                        "source": null,
+                        "date": null,
+                        "amount": {
+                            "amount": null,
+                            "currency": null
+                        },
+                        "providerOrganization": {
+                            "scheme": null,
+                            "id": null,
+                            "legalName": null,
+                            "uri": null
+                        },
+                        "receiverOrganization": {
+                            "scheme": null,
+                            "id": null,
+                            "legalName": null,
+                            "uri": null
+                        },
+                        "uri": null
+                    }
+                ],
+                "milestones": [
+                    {
+                        "id": null,
+                        "title": null,
+                        "description": null,
+                        "dueDate": null,
+                        "dateModified": null,
+                        "status": null,
+                        "documents": [
+                            {
+                                "id": null,
+                                "documentType": null,
+                                "title": null,
+                                "description": null,
+                                "url": null,
+                                "datePublished": null,
+                                "dateModified": null,
+                                "format": null,
+                                "language": null
+                            }
+                        ]
+                    }
+                ],
+                "documents": [
+                    {
+                        "id": null,
+                        "documentType": null,
+                        "title": null,
+                        "description": null,
+                        "url": null,
+                        "datePublished": null,
+                        "dateModified": null,
+                        "format": null,
+                        "language": null
+                    }
+                ]
+            }
+        }
+    ],
+    "language": null
+}] }

--- a/cove/templates/explore_ocds-release.html
+++ b/cove/templates/explore_ocds-release.html
@@ -293,7 +293,7 @@
             <tr>
               <td>{{ release.ocid }}</td>
               <td>{{ release.date }}</td>
-              <td>{{ release.tag|join:", " }}</td>
+              <td>{% if release.tag %}{{ release.tag|join:", " }}{% endif %}</td>
               <td>
                 <ul class="list-unstyled">
                   {% if release.tender.title %} 

--- a/cove/tests.py
+++ b/cove/tests.py
@@ -332,3 +332,13 @@ def test_explore_unconvertable_json(client):
     resp = client.post(data.get_absolute_url(), {'flatten': 'true'})
     assert resp.status_code == 200
     assert b'could not be converted' in resp.content
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('current_app', ['cove-ocds', 'cove-360'])
+def test_explore_page_null_tag(client, current_app):
+    data = SuppliedData.objects.create()
+    data.original_file.save('test.json', ContentFile('{"releases":[{"tag":null}]}'))
+    data.current_app = current_app
+    resp = client.get(data.get_absolute_url())
+    assert resp.status_code == 200

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -172,6 +172,7 @@ def test_accordion(server_url, browser, prefix):
 
 @pytest.mark.parametrize(('prefix', 'source_filename', 'expected_text', 'conversion_successful'), [
     (PREFIX_OCDS, 'tenders_releases_2_releases.json', ['Download Files', 'Save or Share these results'], True),
+    (PREFIX_OCDS, 'ocds_release_nulls.json', ['Download Files', 'Save or Share these results'], True),
     # Conversion should still work for files that don't validate against the schema
     (PREFIX_OCDS, 'tenders_releases_2_releases_invalid.json', ['Download Files', 'Validation Errors', "'id' is a required property"], True),
     # Test UTF-8 support


### PR DESCRIPTION
Modify a template to fix a 500 error due to null `tag` field. https://github.com/OpenDataServices/cove/issues/328

Planned deployment date: Tuesday 19th April

Standing tasks:
- [x] Re-run translations if any text has changed
- [x] Create a new branch `release-201603` if it doesn't exist.
- [x] Deploy to a subdomain on the dev server http://release-201603.dev.cove.opendataservices.coop/ - redo this for any additional commits
- [x] Check that the correct commit has been deployed using the link in the footer http://release-201603.dev.cove.opendataservices.coop/
- [x] Run `CUSTOM_SERVER_URL=http://release-201603.dev.cove.opendataservices.coop/ py.test fts` - redo this for each redeploy to the subomdain

After merge:
- [ ] Run salt highstate on `cove-live`
- [ ] Check that the correct commit has been deployed using the link in the footer http://cove.opendataservices.coop/
- [ ] Run `CUSTOM_SERVER_URL=http://cove.opendataservices.coop/ py.test fts` on a local copy of the updated live branch
- [ ] Run salt highstate on `cove-live-ocds`
- [ ] Check that the correct commit has been deployed using the link in the footer http://standard.open-contracting.org/validator/
- [ ] Run `CUSTOM_SERVER_URL=http://standard.open-contracting.org PREFIX_OCDS=/validator/ py.test fts ` on a local copy of the updated live branch
- [ ] Check that changes on live are merged back into master too