### PR TITLE
[#380] Layout changes to make the workflow better

### DIFF
--- a/cove/static/dataexplore/css/style.css
+++ b/cove/static/dataexplore/css/style.css
@@ -3,6 +3,10 @@
   text-decoration:none;
 }
 
+.page-header a.btn {
+ float:right
+}
+
 h1.application-name {
   margin-top: 0;
 }
@@ -91,9 +95,33 @@ a:hover {
 }
 
 .success-button {
-padding-bottom: 20px;
+  padding-bottom: 20px;
 }
 
 .spinner {
-margin-bottom: 20px;
+  margin-bottom: 20px;
+}
+
+.explanation {
+  font-size: 1.2em;
+}
+
+a.anchor::before {
+  display: block;
+  content: " ";
+  margin-top: -30px;
+  height: 30px;
+  visibility: hidden;
+}
+
+.message  {
+  margin-left:30px;
+  margin-bottom: 10px;
+}
+.message span {
+  margin-left: -30px;
+  padding-right:15px;
+}
+.key-facts ul {
+  padding-left: 15px;
 }

--- a/cove/templates/base_generic.html
+++ b/cove/templates/base_generic.html
@@ -20,7 +20,7 @@
 </head>
 <body>
   {% block banner %}
-  <div style="background-color: orange; color: black; width: 100%; text-align: center; font-weight: bold; position: fixed; right: 0; left: 0; z-index: 1030">This tool is <em>alpha</em>. Please report any problems on <a href="https://github.com/OpenDataServices/cove/issues">GitHub issues</a>.</div>
+  <div style="background-color: orange; color: black; width: 100%; text-align: center; font-weight: bold; right: 0; left: 0">This tool is <em>alpha</em>. Please report any problems on <a href="https://github.com/OpenDataServices/cove/issues">GitHub issues</a>.</div>
   {% endblock banner %}
   {% block full_width_header %}
   {% endblock %}

--- a/cove/templates/explore.html
+++ b/cove/templates/explore.html
@@ -15,8 +15,14 @@
 {# Translators: JSON probably does not need a transalation: http://www.json.org/ #}
 {% trans 'JSON' as JSON %}
 
+
+{% block key_facts %}
+{% endblock %}
+
+{% block converted_files %}
+
 <!--Download Converted Files-->
-<div class="panel {% if conversion_error %}panel-warning{% else %}panel-success{% endif %}">
+<div class="panel {% if conversion_error %}panel-danger{% elif conversion_warning_messages or conversion_warning_messages_titles %}panel-warning{% else %}panel-success{% endif %}">
   <div class="panel-heading">
     <h4 class="panel-title">
       <span class="glyphicon glyphicon-download" aria-hidden="true"></span>{% trans 'Download Files' %}
@@ -81,23 +87,32 @@
     
   </div>
 </div>
+{% endblock %}
+
 
 {% if conversion_warning_messages %}
+  <a name="conversion-warning" class="anchor"></a>
   <div class="panel panel-warning">
     <div class="panel-heading">
       <h4 class="panel-title">
+        
         {% trans 'Conversion Warnings' %}
       </h4>
     </div>
     <div class="panel-body">
-      {% for warning_message in conversion_warning_messages %}
-        <p>{{warning_message}}</p>
-      {% endfor %}
+      <p class="explanation">In order to validate your data we need to convert it. During that conversion we found the following issues:</p>
+      <ul>
+        {% for warning_message in conversion_warning_messages %}
+          <li>{{warning_message}}</li>
+        {% endfor %}
+      </ul>
     </div>
   </div>
 {% endif %}
 
+
 {% if conversion_warning_messages_titles %}
+  <a name="conversion-warning" class="anchor"></a>
   <div class="panel panel-warning">
     <div class="panel-heading">
       <h4 class="panel-title">
@@ -105,14 +120,18 @@
       </h4>
     </div>
     <div class="panel-body">
+    <p class="explanation">In order to validate your data we need to convert it. During that conversion we found the following issues:</p>
+    <ul>
       {% for warning_message in conversion_warning_messages_titles %}
-        <p>{{warning_message}}</p>
+        <li>{{warning_message}}</li>
       {% endfor %}
+    </ul>
     </div>
   </div>
 {% endif %}
 
 {% if validation_errors %}
+  <a name="validation-errors" class="anchor"></a>
   <div class="panel panel-danger">
     <div class="panel-heading pointer" role="region" aria-expanded="true" aria-controls="validationTable" data-toggle="collapse" data-target="#validationTable">
       <h4 class="panel-title">

--- a/cove/templates/explore_360.html
+++ b/cove/templates/explore_360.html
@@ -2,40 +2,153 @@
 {% load i18n %}
 {% load cove_tags %}
 
-{% block explore_content %}
+{% block key_facts %}
 
 <div class="row">
-  <div class="col-md-12">
-    <div class="panel panel-primary">
+  <div class="col-md-6">
+    <div class="panel {% if validation_errors %}panel-danger{% elif conversion_warning_messages or conversion_warning_messages_titles %}panel-warning{% else %}panel-success{% endif %}">
       <div class="panel-heading">
-        <h4 class="panel-title">{% trans 'Key Facts' %}</h4>
+        <h4 class="panel-title">{% trans 'Headlines' %}</h4>
       </div>
       <div class="panel-body">
-         <p>
-           {% trans "Data " %} 
-           {% if source_url %}
-              {% trans "downloaded from " %} {{source_url}} 
-           {% else %}
-             {% trans "uploaded " %} 
-           {% endif %}
-           {% trans "on " %} {{created_date}} 
-         </p>
-         <p>
-           {% blocktrans %}This file contains{% endblocktrans %} {{grants_aggregates.count}} {% blocktrans %} grants {% endblocktrans %}
-         </p>
-         <p>
-         {% trans "This file " %} 
-            {% if validation_errors %} <b> {% trans "failed " %} </b> {% else %} {% trans "passed " %} {% endif %}
-            {% blocktrans %}validation against the {% endblocktrans %}<a href="http://www.threesixtygiving.org/standard/reference/#toc-360giving-json-schemas">360Giving JSON Package Schema</a>.
-         </p>
-         {% if grants_aggregates.duplicate_ids %} 
-              <b> {% blocktrans %}There are{% endblocktrans %} {{ grants_aggregates.duplicate_ids|length }} {% blocktrans %}duplicate grant IDs in this package.{% endblocktrans %}</b>
-         {% endif %}
+
+        {% if conversion_warning_messages or conversion_warning_messages_titles %}
+          <div class="conversion message"><span class="glyphicon glyphicon-flag" aria-hidden="true"></span>{% blocktrans %}Please read the <a href="#conversion-warning">conversion warnings</a> below.{% endblocktrans %}</div>
+        {% endif %} 
+        <div class="validation message">  
+        {% if validation_errors %}
+          <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> <b> {% trans "Failed " %} </b>
+        {% else %} 
+          <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>{% trans "Passed " %} 
+        {% endif %}
+        {% blocktrans %}validation against {% endblocktrans %}<a href="http://www.threesixtygiving.org/standard/reference/#toc-360giving-json-schemas">360Giving JSON Package Schema</a>.
+        {% if validation_errors %}<br/>{% blocktrans %}See <a href="#validation-errors">Validation Errors</a> below.{% endblocktrans %}{% endif %}
+        </div>
+
+         <div class="key-facts message">
+           <strong>At a glance</strong>
+           <ul>
+             <li>
+             {% blocktrans count count=grants_aggregates.count %}This file contains {{count}} grant.
+             {% plural %}
+              This file contains {{count}} grants.
+             {% endblocktrans %}
+             </li>
+            
+             {% if grants_aggregates.duplicate_ids %} 
+             <li>
+                  <b> {% blocktrans %}There are{% endblocktrans %} {{ grants_aggregates.duplicate_ids|length }} {% blocktrans %}duplicate grant IDs in this package.{% endblocktrans %}</b>
+             </li>
+             {% endif %}
+             
+            <!-- <li>
+              {% if data_only %}
+                {% blocktrans count count=data_only.count %}
+                  This file uses {{count}} additional field not used in the standard.
+                {% plural %}
+                  This file uses {{count}} additional fields not used in the standard.
+                {% endblocktrans %}
+              {% endif %}
+             </li>-->
+
+             <li>
+               {% trans "Data " %} 
+               {% if source_url %}
+                  {% trans "downloaded from " %} {{source_url}} 
+               {% else %}
+                 {% trans "uploaded " %} 
+               {% endif %}
+               {% trans "on " %} {{created_date}}
+            </li>
+           </ul>
+         </div>
+      </div>
+    </div>
+  </div>
+  
+  <div class="col-md-6">
+    <div class="panel {% if conversion_error %}panel-danger{% elif conversion_warning_messages or conversion_warning_messages_titles %}panel-warning{% else %}panel-success{% endif %}">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          {% trans 'Convert' %}
+        </h4>
+      </div>
+          
+      <div class="panel-body">
+        <div class="conversion message">
+          {% if conversion_warning_messages or conversion_warning_messages_titles %}
+            <p><span class="glyphicon glyphicon-flag" aria-hidden="true"></span>There were <a href="#conversion-warning">conversion errors</a> when processing your file. The converted data may not represent your data as you want it to be.</p>
+          {% endif %}
+          {% if conversion == 'flatten' %}
+            <p>We have tried to convert your JSON into a spreadsheet format.</p><p>The results can be seen below.</p>
+            <ul class="list-unstyled left-space">
+              <li>
+                <a href="{{original_file.url}}">{{JSON}} ({{original}})</a> {{original_file.size|filesizeformat }}
+              </li>
+              {% if not conversion_error %}
+                <li>
+                  <span class="glyphicon glyphicon-download" aria-hidden="true"></span><a href="{{converted_url}}.xlsx">{{xlsx}} ({{converted}})</a> {{converted_file_size|filesizeformat }}
+                </li>
+                <!--Only show for 360Giving files-->
+                {% if request.cove_config.convert_titles %}
+                  <li>
+                    <span class="glyphicon glyphicon-download" aria-hidden="true"></span><a href="{{converted_url}}-titles.xlsx">{{xlsx_titles}} ({{converted}})</a> {{converted_file_size_titles|filesizeformat }}
+                  </li>
+                {% endif %}
+              {% endif %}
+            </ul>
+            {% if conversion_error %}
+                <p>{% blocktrans %}The JSON could not be converted to Spreadsheet due to the error:{% endblocktrans %} {{ conversion_error }}</p>
+
+                {% include 'error_extra.html' %}
+            {% endif %}
+          
+          {% elif conversion == 'unflatten' %}
+            <p>We have tried to convert your data into JSON format.</p><p>The results can be seen below.</p>
+            <ul class="list-unstyled">
+              <li>
+                <a href="{{original_file.url}}">
+                  {% if file_type == 'xlsx' %}
+                      <span class="glyphicon glyphicon-download" aria-hidden="true"></span>{{xlsx}} ({{original}})
+                  {% elif file_type == 'csv' %}
+                      <span class="glyphicon glyphicon-download" aria-hidden="true"></span>{{csv}} ({{original}})
+                  {% endif %}
+                  </a> 
+                  {{original_file.size|filesizeformat }}
+                </li>
+                <li>
+                  <a href="{{converted_url}}"><span class="glyphicon glyphicon-download" aria-hidden="true"></span>{{JSON}} ({{converted}})</a> {{converted_file_size|filesizeformat }}
+                </li>
+            </ul>
+
+          {% else %}
+            <ul class="list-unstyled">
+              <li>
+                <a href="{{original_file.url}}"><span class="glyphicon glyphicon-download" aria-hidden="true"></span>{{JSON}} ({{original}})</a> {{original_file.size|filesizeformat }}
+                {% if conversion == 'flattenable' %}
+                  <br/>
+                  <br/>
+                  <form method="post">
+                    <button name="flatten" value="true" type="submit" class="btn btn-info btn-sm">{% blocktrans %}Convert to Spreadsheet{% endblocktrans %}</button>
+                    {% csrf_token %}
+                  </form>
+                {% endif %}
+              </li>
+            </ul>
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>
 </div><!--End Row -->
 
+{% endblock %}
+
+<!--Overide converted_files block in explore.html-->
+{% block converted_files %}
+{% endblock %}
+
+{% block explore_content %}
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-primary">

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -201,13 +201,13 @@ def test_accordion(server_url, browser, prefix):
     (PREFIX_OCDS, 'tenders_releases_2_releases_not_json.json', 'not well formed JSON', False),
     (PREFIX_OCDS, 'tenders_releases_2_releases.xlsx', 'Download Files', True),
     (PREFIX_OCDS, 'badfile.json', 'Statistics can not produced', True),
-    (PREFIX_360, 'WellcomeTrust-grants_fixed_2_grants.json', ['Download Files',
+    (PREFIX_360, 'WellcomeTrust-grants_fixed_2_grants.json', ['Convert',
                                                            'Save or Share these results',
                                                            'Unique Grant IDs: 2',
                                                            'Duplicate IDs: 2',
                                                            'Duplicate IDs: 2',
                                                            'This file contains 4 grants',
-                                                           'This file failed validation against',
+                                                           'Failed validation against',
                                                            'There are 2 duplicate grant IDs in this package.',
                                                            'Silent Signal',
                                                            'Showing 1 to 4 of 4 entries',
@@ -215,12 +215,12 @@ def test_accordion(server_url, browser, prefix):
                                                            'Data source',
                                                            'Date is not in datetime format'], True),
     # Test a 360 spreadsheet with titles, rather than fields
-    (PREFIX_360, 'WellcomeTrust-grants_2_grants.xlsx', 'Download Files', True),
+    (PREFIX_360, 'WellcomeTrust-grants_2_grants.xlsx', 'Convert', True),
     # Test that titles that aren't in the rollup are converted correctly
     # (See if statement in check_url_input_result_page).
-    (PREFIX_360, 'WellcomeTrust-grants_2_grants_titleswithoutrollup.xlsx', 'Download Files', True),
+    (PREFIX_360, 'WellcomeTrust-grants_2_grants_titleswithoutrollup.xlsx', 'Convert', True),
     # Test a 360 csv in cp1252 incoding
-    (PREFIX_360, 'WellcomeTrust-grants_2_grants_cp1252.csv', 'Download Files', True),
+    (PREFIX_360, 'WellcomeTrust-grants_2_grants_cp1252.csv', 'Convert', True),
     # Test a non-valid file.
     (PREFIX_360, 'paul-hamlyn-foundation-grants_dc.txt', 'We can only process json, csv and xlsx files', False),
     # Test a unconvertable spreadsheet (main sheet "grants" is missing)


### PR DESCRIPTION
Moves Key Facts to Headlines and to the top of the page
Turns Convert into a half size box at the top
Customises the messages a bit and adds glyphicons
Pluralises grant(s) properly
Hopefully does this without messing up OCDS