### PR TITLE
[#404] Reports on funding org prefixes

### DIFF
--- a/cove/fixtures/WellcomeTrust-grants_broken_grants.json
+++ b/cove/fixtures/WellcomeTrust-grants_broken_grants.json
@@ -1,0 +1,163 @@
+{
+    "grants": [
+        {
+            "currency": "GBP", 
+            "grantProgramme": [
+                {
+                    "code": "AAC", 
+                    "title": "Arts Awards Funding Committee"
+                }
+            ], 
+            "id": "360G-wellcometrust-105177/Z/14/Z", 
+            "Co-applicant(s)": "Mr Bentley Crudgington, Mr Gary Thomas", 
+            "title": "Silent Signal.", 
+            "fundingOrganization": [
+                {
+                    "id": "GB-CHC-210183", 
+                    "name": "The Wellcome Trust"
+                }
+            ], 
+            "dateModified": "2015-03-14", 
+            "Data source": "http://www.wellcome.ac.uk/Managing-a-grant/Grants-awarded/index.htm", 
+            "plannedDates": [
+                {
+                    "duration": 30
+                }
+            ], 
+            "Surname of applicant": "Addison", 
+            "Grant number": "105177/Z/14/Z", 
+            "amountAwarded": 152505.03, 
+            "recipientOrganization": [
+                {
+                    "addressLocality": "London", 
+                    "name": "Animate Project Limited"
+                }
+            ], 
+            "Grant type": "Large Arts Awards", 
+            "Full name of applicant": "Miss Abigail Addison", 
+            "awardDate": "24/07/2014",
+            "commitmentTransaction": [
+              {
+                "id": "111",
+                "value": 23.50
+              }
+            ]
+        }, 
+        {
+            "currency": "GBP", 
+            "grantProgramme": [
+                {
+                    "code": "AAC", 
+                    "title": "Arts Awards Funding Committee"
+                }
+            ], 
+            "id": "360G-wellcometrust-105177/Z/14/Z", 
+            "Co-applicant(s)": "Mr Bentley Crudgington, Mr Gary Thomas", 
+            "title": "Silent Signal.", 
+            "fundingOrganization": [
+                {
+                    "id": "RUBBISH1-GB-CHC-210183", 
+                    "name": "The Wellcome Trust"
+                }
+            ], 
+            "dateModified": "13-03-2015", 
+            "Data source": "http://www.wellcome.ac.uk/Managing-a-grant/Grants-awarded/index.htm", 
+            "plannedDates": [
+                {
+                    "duration": 30
+                }
+            ], 
+            "Surname of applicant": "Addison", 
+            "Grant number": "105177/Z/14/Z", 
+            "amountAwarded": 152505, 
+            "recipientOrganization": [
+                {
+                    "id": "RUBBISH2-COH-RC000659", 
+                    "addressLocality": "London", 
+                    "name": "Animate Project Limited"
+                }
+            ], 
+            "Grant type": "Large Arts Awards", 
+            "Full name of applicant": "Miss Abigail Addison", 
+            "awardDate": "24/07/2014"
+        }, 
+        {
+            "recipientOrganization": [
+                {
+                    "id": "GB-COH-RC000659", 
+                    "addressLocality": "Leicester", 
+                    "name": "UNIVERSITY OF LEICESTER", 
+                    "companyNumber": "RC000659"
+                }
+            ], 
+            "currency": "GBP", 
+            "grantProgramme": [
+                {
+                    "code": "AAC", 
+                    "title": "Arts Awards Funding Committee"
+                }
+            ], 
+            "Department": "Department of Museum Studies", 
+            "id": "360G-wellcometrust-105182/Z/14/Z", 
+            "title": "Exceptional and Extraordinary: unruly bodies and minds in the medical museum.", 
+            "fundingOrganization": [
+                {
+                    "id": "GB-CHC-210183", 
+                    "name": "The Wellcome Trust"
+                }
+            ], 
+            "dateModified": "13-03-2015", 
+            "Data source": "http://www.wellcome.ac.uk/Managing-a-grant/Grants-awarded/index.htm", 
+            "plannedDates": [
+                {
+                    "duration": 25
+                }
+            ], 
+            "Surname of applicant": "Sandell", 
+            "Grant number": "105182/Z/14/Z", 
+            "amountAwarded": 178990, 
+            "Grant type": "Large Arts Awards", 
+            "Full name of applicant": "Prof Richard Sandell", 
+            "awardDate": "24/07/2014"
+        }, 
+        {
+            "recipientOrganization": [
+                {
+                    "id": "GB-COH-RC000659", 
+                    "addressLocality": "Leicester", 
+                    "name": "UNIVERSITY OF LEICESTER", 
+                    "companyNumber": "RC000659"
+                }
+            ], 
+            "currency": "GBP", 
+            "grantProgramme": [
+                {
+                    "code": "AAC", 
+                    "title": "Arts Awards Funding Committee"
+                }
+            ], 
+            "Department": "Department of Museum Studies", 
+            "id": "360G-wellcometrust-105182/Z/14/Z", 
+            "title": "Exceptional and Extraordinary: unruly bodies and minds in the medical museum.", 
+            "fundingOrganization": [
+                {
+                    "id": "GB-CHC-210183", 
+                    "name": "The Wellcome Trust"
+                }
+            ], 
+            "dateModified": "13-03-2015", 
+            "Data source": "http://www.wellcome.ac.uk/Managing-a-grant/Grants-awarded/index.htm", 
+            "plannedDates": [
+                {
+                    "duration": 25
+                }
+            ], 
+            "Surname of applicant": "Sandell", 
+            "Grant number": "105182/Z/14/Z", 
+            "amountAwarded": 178990, 
+            "Grant type": "Large Arts Awards", 
+            "Full name of applicant": "Prof Richard Sandell", 
+            "awardDate": "24/07/2014"
+        } 
+    ]
+}

--- a/cove/lib/threesixtygiving.py
+++ b/cove/lib/threesixtygiving.py
@@ -67,16 +67,13 @@ def get_grants_aggregates(json_data):
             if currency:
                 distinct_currency.add(currency)
 
-    recipient_org_identifier_prefixes = defaultdict(int)
-    recipient_org_identifiers_unrecognised_prefixes = defaultdict(int)
-
-    for recipient_org_identifier in distinct_recipient_org_identifier:
-        for prefix in org_prefixes:
-            if recipient_org_identifier.startswith(prefix):
-                recipient_org_identifier_prefixes[prefix] += 1
-                break
-        else:
-            recipient_org_identifiers_unrecognised_prefixes[recipient_org_identifier] += 1
+    recipient_org_prefixes = get_prefixes(distinct_recipient_org_identifier)
+    recipient_org_identifier_prefixes = recipient_org_prefixes['prefixes']
+    recipient_org_identifiers_unrecognised_prefixes = recipient_org_prefixes['unrecognised_prefixes']
+    
+    funding_org_prefixes = get_prefixes(distinct_funding_org_identifier)
+    funding_org_identifier_prefixes = funding_org_prefixes['prefixes']
+    funding_org_identifiers_unrecognised_prefixes = funding_org_prefixes['unrecognised_prefixes']
 
     return {
         'count': count,
@@ -92,4 +89,25 @@ def get_grants_aggregates(json_data):
         'distinct_currency': distinct_currency,
         'recipient_org_identifier_prefixes': recipient_org_identifier_prefixes,
         'recipient_org_identifiers_unrecognised_prefixes': recipient_org_identifiers_unrecognised_prefixes,
+        'funding_org_identifier_prefixes': funding_org_identifier_prefixes,
+        'funding_org_identifiers_unrecognised_prefixes': funding_org_identifiers_unrecognised_prefixes
+    }
+
+
+def get_prefixes(distinct_identifiers):
+
+    org_identifier_prefixes = defaultdict(int)
+    org_identifiers_unrecognised_prefixes = defaultdict(int)
+
+    for org_identifier in distinct_identifiers:
+        for prefix in org_prefixes:
+            if org_identifier.startswith(prefix):
+                org_identifier_prefixes[prefix] += 1
+                break
+        else:
+            org_identifiers_unrecognised_prefixes[org_identifier] += 1
+    
+    return {
+        'prefixes': org_identifier_prefixes,
+        'unrecognised_prefixes': org_identifiers_unrecognised_prefixes,
     }

--- a/cove/static/dataexplore/css/style.css
+++ b/cove/static/dataexplore/css/style.css
@@ -133,5 +133,13 @@ a.anchor::before {
   padding-right:15px;
 }
 .key-facts ul {
-  padding-left: 15px;
+  padding-left: 0;
+  list-style: none;
+}
+.key-facts ul li {
+  margin: 4px 0;
+}
+
+.key-facts .glyphicon-flag {
+  color: #a94442;
 }

--- a/cove/templates/explore_360.html
+++ b/cove/templates/explore_360.html
@@ -17,7 +17,7 @@
         {% endif %} 
         <div class="validation message">  
         {% if validation_errors %}
-          <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> <b> {% trans "Failed " %} </b>
+          <span class="glyphicon glyphicon-remove" aria-hidden="true"></span><b>{% trans "Failed " %}</b>
         {% else %} 
           <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>{% trans "Passed " %} 
         {% endif %}
@@ -28,7 +28,7 @@
          <div class="key-facts message">
            <strong>At a glance</strong>
            <ul>
-             <li>
+             <li><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
              {% blocktrans count count=grants_aggregates.count %}This file contains {{count}} grant.
              {% plural %}
               This file contains {{count}} grants.
@@ -36,27 +36,42 @@
              </li>
             
              {% if grants_aggregates.duplicate_ids %} 
-             <li>
-                  <b> {% blocktrans %}There are{% endblocktrans %} {{ grants_aggregates.duplicate_ids|length }} {% blocktrans %}duplicate grant IDs in this package.{% endblocktrans %}</b>
+             <li><span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+                  {% blocktrans count count=grants_aggregates.duplicate_ids|length %}There is {{ count }} <a href="#key-field-info">duplicate grant ID</a> in this package.
+                  {% plural %}
+                  There are {{ count }} <a href="#key-field-info">duplicate grant IDs</a> in this package.
+                  {% endblocktrans %}
              </li>
              {% endif %}
              {% if grants_aggregates.recipient_org_identifiers_unrecognised_prefixes %} 
-             <li>
-                  <b> {% blocktrans %}There are{% endblocktrans %} {{ grants_aggregates.recipient_org_identifiers_unrecognised_prefixes|length }} {% blocktrans %}unrecognised organisation prefixes in this package.{% endblocktrans %}</b>
+             <li><span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+                  {% blocktrans count count=grants_aggregates.recipient_org_identifiers_unrecognised_prefixes|length %}
+                  There is {{ count }} <a href="#key-field-info">unrecognised recipient organisation prefix</a> in this package.
+                  {% plural %}
+                  There are {{ count }} <a href="#key-field-info">unrecognised recipient organisation prefixes</a> in this package.
+                  {% endblocktrans %}
              </li>
              {% endif %}
-             
-            <li>
-              {% if data_only %}
+             {% if grants_aggregates.funding_org_identifiers_unrecognised_prefixes %} 
+             <li><span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+                  {% blocktrans count count=grants_aggregates.funding_org_identifiers_unrecognised_prefixes|length %}
+                  There is {{ count }} <a href="#key-field-info">unrecognised funding organisation prefix</a> in this package.
+                  {% plural %}
+                  There are {{ count }} <a href="#key-field-info">unrecognised funding organisation prefixes</a> in this package.
+                  {% endblocktrans %}
+             </li>
+             {% endif %}
+             {% if data_only %}
+            <li><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
                 {% blocktrans count count=data_only|length %}
-                  This file uses {{count}} <a href="#additional-fields">additional field</a>ot used in the standard.
+                  This file uses {{count}} <a href="#additional-fields">additional field</a> not used in the standard.
                 {% plural %}
                   This file uses {{count}} <a href="#additional-fields">additional fields</a> not used in the standard.
                 {% endblocktrans %}
-              {% endif %}
              </li>
+             {% endif %}
 
-             <li>
+             <li><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
                {% trans "Data " %} 
                {% if source_url %}
                   {% trans "downloaded from " %} {{source_url}} 
@@ -154,6 +169,7 @@
 {% endblock %}
 
 {% block explore_content %}
+<a id="key-field-info"></a>
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-primary">
@@ -198,12 +214,20 @@
               <b>{% trans "Funder Organisation IDs:" %}</b> {{grants_aggregates.distinct_funding_org_identifier|length}}
             </a>
             <br/>
+            <a data-toggle="modal" data-target=".funding-org-identifier-prefixes">
+              <b>{% trans "Good Funding Org ID Prefixes:" %}</b> {{grants_aggregates.funding_org_identifier_prefixes|length}}
+            </a>
+            <br/>
+            <a data-toggle="modal" data-target=".funding-org-identifiers-unrecognised-prefixes">
+              <b>{% trans "Unrecognised Funding Org ID Prefixes:" %}</b> {{grants_aggregates.funding_org_identifiers_unrecognised_prefixes|length}}
+            </a>
+            <br/>
             <a data-toggle="modal" data-target=".distinct-recipient-org-identifier">
               <b>{% trans "Recipient Organisation IDs:" %}</b> {{grants_aggregates.distinct_recipient_org_identifier|length}}
             </a>
             <br/>
             <a data-toggle="modal" data-target=".recipient-org-identifier-prefixes">
-              <b>{% trans "Recipient Org ID Prefixes:" %}</b> {{grants_aggregates.recipient_org_identifier_prefixes|length}}
+              <b>{% trans "Good Recipient Org ID Prefixes:" %}</b> {{grants_aggregates.recipient_org_identifier_prefixes|length}}
             </a>
             <br/>
             <a data-toggle="modal" data-target=".recipient-org-identifiers-unrecognised-prefixes">
@@ -219,6 +243,8 @@
 
 {% cove_modal_list className="duplicate-id-modal" modalTitle="Duplicate IDs" itemList=grants_aggregates.duplicate_ids %}
 {% cove_modal_list className="distinct-funding-org-identifier" modalTitle="Funder Organisation IDs" itemList=grants_aggregates.distinct_funding_org_identifier %}
+{% cove_modal_list className="funding-org-identifier-prefixes" modalTitle="Funding Organisation ID Prefixes" itemList=grants_aggregates.funding_org_identifier_prefixes %}
+{% cove_modal_list className="funding-org-identifiers-unrecognised-prefixes" modalTitle="Unrecognised Funding Organisation ID Prefixes" itemList=grants_aggregates.funding_org_identifiers_unrecognised_prefixes %}
 {% cove_modal_list className="distinct-recipient-org-identifier" modalTitle="Recipient Organisation IDs" itemList=grants_aggregates.distinct_recipient_org_identifier %}
 {% cove_modal_list className="recipient-org-identifier-prefixes" modalTitle="Recipient Organisation ID Prefixes" itemList=grants_aggregates.recipient_org_identifier_prefixes %}
 {% cove_modal_list className="recipient-org-identifiers-unrecognised-prefixes" modalTitle="Unrecognised Recipient Organisation ID Prefixes" itemList=grants_aggregates.recipient_org_identifiers_unrecognised_prefixes %}

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -216,8 +216,12 @@ def test_accordion(server_url, browser, prefix):
                                                            'This file uses 7 additional fields not used in the standard.',
                                                            'Recipient Org ID Prefixes: 1',
                                                            'Unrecognised Recipient Org ID Prefixes: 1',
-                                                           'There are 1 unrecognised organisation prefixes in this package.',
+                                                           'There is 1 unrecognised recipient organisation prefix in this package.',
                                                            'Date is not in datetime format'], True),
+    (PREFIX_360, 'WellcomeTrust-grants_broken_grants.json', ['Convert',
+                                                           'Funder Organisation IDs: 2',
+                                                           'Unrecognised Funding Org ID Prefixes: 1',
+                                                           'There is 1 unrecognised funding organisation prefix in this package.'], True),
     # Test a 360 spreadsheet with titles, rather than fields
     (PREFIX_360, 'WellcomeTrust-grants_2_grants.xlsx', 'Convert', True),
     # Test that titles that aren't in the rollup are converted correctly


### PR DESCRIPTION
This started off as trying to see why funding org prefixes were not
picked up as failing, and ended up being a copy and paste job of the
receiver org prefixes work.

See if it is useful.

<!---
@huboard:{"order":61.6875,"milestone_order":410,"custom_state":""}
-->
