### PR TITLE
Allows html in error messages

### DIFF
--- a/cove/templates/error.html
+++ b/cove/templates/error.html
@@ -3,9 +3,12 @@
 {% block content %}
 
 <div class="panel panel-warning">
-  <div class="panel-heading">{{ sub_title | linebreaks }}</div>
+  <div class="panel-heading">
+    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+    {{ sub_title }}
+  </div>
   <div class="panel-body">
-    {{ msg | linebreaks }}
+    {{ msg | safe | linebreaks }}
 
     {% include 'error_extra.html' %}
   </div>

--- a/cove/views.py
+++ b/cove/views.py
@@ -111,7 +111,8 @@ def explore(request, pk):
                     'sub_title': _("Sorry we can't process that data"),
                     'link': 'cove:index',
                     'link_text': _('Try Again'),
-                    'msg': _('We think you tried to upload a JSON file, but it is not well formed JSON.\n\nError message: {}'.format(err))
+                    'msg': _('We think you tried to upload a JSON file, but it is not well formed JSON.\n\n<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> <strong>Error message:</strong> {}'.format(err)),
+                    'error': format(err)
                 })
         if request.current_app == 'cove-ocds' and 'records' in json_data:
             context['conversion'] = None


### PR DESCRIPTION
I wanted to make one of the error messages look nicer- specifically when
tender_releases_2_releases_not_json.json was loaded
To do this I think the error message in views.py needs to contain html
I've added the | safe option to the html template

You may not think this is a good idea! Please review.