### PR TITLE
Update Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,24 @@
-pip==8.1.2
-Django==1.8.16 # rq.filter: <1.9
+pip==9.0.1
+Django==1.8.17 # rq.filter: <1.9
 -e git+https://github.com/OpenDataServices/flatten-tool.git@fc074cd0a4a25b925a05fc0dda0488f17d1c28d5#egg=flattentool
-django-bootstrap3==7.0.1
-django-debug-toolbar==1.4
-requests==2.10.0
+django-bootstrap3==8.0.0
+django-debug-toolbar==1.6
+requests==2.12.4
 dealer==2.0.5
-django-environ==0.4.0
+django-environ==0.4.1
 jsonschema==2.5.1
-raven==5.23.0
+raven==5.32.0
 strict-rfc3339==0.7
-rfc3987==1.3.6
+rfc3987==1.3.7
 rfc6266==0.0.4
 ## The following requirements were added by pip freeze:
-contextlib2==0.5.3
+contextlib2==0.5.4
 et-xmlfile==1.0.1
-jdcal==1.2
+jdcal==1.3
 jsonref==0.1
 LEPL==5.1.3
 openpyxl==2.3.5
-pytz==2016.6.1
-schema==0.6.0
+pytz==2016.10
+schema==0.6.5
 six==1.10.0
-sqlparse==0.1.19
+sqlparse==0.2.2

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -1,9 +1,6 @@
 -r requirements.in
 
 flake8
-# flake8 requires pyflakes <1.1
-pyflakes<1.1
-#^^ rq.filter: <1.1
 pytest
 pytest-django
 pytest-cov

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,63 +1,58 @@
-pip==8.1.2
-Django==1.8.16 # rq.filter: <1.9
+pip==9.0.1
+Django==1.8.17 # rq.filter: <1.9
 -e git+https://github.com/OpenDataServices/flatten-tool.git@fc074cd0a4a25b925a05fc0dda0488f17d1c28d5#egg=flattentool
-django-bootstrap3==7.0.1
-django-debug-toolbar==1.4
-requests==2.10.0
+django-bootstrap3==8.0.0
+django-debug-toolbar==1.6
+requests==2.12.4
 dealer==2.0.5
-django-environ==0.4.0
+django-environ==0.4.1
 jsonschema==2.5.1
-raven==5.23.0
+raven==5.32.0
 strict-rfc3339==0.7
-rfc3987==1.3.6
+rfc3987==1.3.7
 rfc6266==0.0.4
 
 
-flake8==2.6.2
-# flake8 requires pyflakes <1.1
-pyflakes==1.0.0 # rq.filter: <1.1
-pytest==2.9.2
-pytest-django==2.9.1
-pytest-cov==2.3.0
-pytest-localserver==0.3.5
-pytest-xdist==1.14
+flake8==3.2.1
+pytest==3.0.5
+pytest-django==3.1.2
+pytest-cov==2.4.0
+pytest-localserver==0.3.6
+pytest-xdist==1.15.0
 coveralls==1.1
-selenium==2.53.6
-transifex-client==0.12.1
-libsass==0.11.1
-Sphinx==1.4.5
+selenium==3.0.2
+transifex-client==0.12.2
+libsass==0.12.3
+Sphinx==1.5.1
 recommonmark==0.4.0
-hypothesis==3.5.3
-
+hypothesis==3.6.1
 ## The following requirements were added by pip freeze:
-alabaster==0.7.8
+alabaster==0.7.9
 apipkg==1.4
 Babel==2.3.4
 CommonMark==0.5.4
-contextlib2==0.5.3
-coverage==4.1
+contextlib2==0.5.4
+coverage==4.3.1
 docopt==0.6.2
-docutils==0.12
+docutils==0.13.1
 et-xmlfile==1.0.1
 execnet==1.4.1
 imagesize==0.7.1
-jdcal==1.2
-Jinja2==2.8
+jdcal==1.3
+Jinja2==2.9.3
 jsonref==0.1
 LEPL==5.1.3
 MarkupSafe==0.23
-mccabe==0.5.0
+mccabe==0.5.3
 openpyxl==2.3.5
-py==1.4.31
-pycodestyle==2.0.0
+py==1.4.32
+pycodestyle==2.2.0
+pyflakes==1.3.0
 Pygments==2.1.3
-pytz==2016.6.1
-schema==0.6.0
+pytz==2016.10
+schema==0.6.5
 six==1.10.0
 snowballstemmer==1.2.1
-spark-parser==1.4.0
-sqlparse==0.1.19
-uncompyle6==2.9.3
-urllib3==1.16
-Werkzeug==0.11.10
-xdis==3.2.3
+sqlparse==0.2.2
+urllib3==1.19.1
+Werkzeug==0.11.15

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,7 +20,7 @@ pytest-cov==2.4.0
 pytest-localserver==0.3.6
 pytest-xdist==1.15.0
 coveralls==1.1
-selenium==3.0.2
+selenium==2.53.6
 transifex-client==0.12.2
 libsass==0.12.3
 Sphinx==1.5.1


### PR DESCRIPTION
This PR updates most requirements to their latest versions https://requires.io/github/OpenDataServices/cove/requirements/?branch=490-update-requirements

Not the latest version are:
* `openpyxl` because flatten-tool doesn't support the latest version https://github.com/OpenDataServices/flatten-tool/issues/135
* `PyFlakes`, because flake8 requests <1.4.0 https://github.com/PyCQA/flake8/blob/master/setup.py
* `CommonMark` because recommonmark requires particular version
* `selenium` because this doesn't work with the version of firefox on travis - https://travis-ci.org/OpenDataServices/cove/builds/190265676 - going forward we probably want to switch to PhantomJS https://github.com/OpenDataServices/cove/issues/518