### PR TITLE
[#528] codelist verification.

### DIFF
--- a/cove/fixtures/tenders_releases_2_releases_codelists.json
+++ b/cove/fixtures/tenders_releases_2_releases_codelists.json
@@ -1,0 +1,115 @@
+{
+    "publisher": {
+        "scheme": null, 
+        "name": "Buyandsell.gc.ca", 
+        "uri": "https://buyandsell.gc.ca", 
+        "uid": null
+    }, 
+    "releases": [
+        {
+            "date": "2014-03-25T00:00:00.00Z", 
+            "language": "English", 
+            "id": "Buyandsell.gc.ca-2014-11-07-89f689cd-e784-4374-bb17-94144679d46f", 
+            "ocid": "PW-14-00627094", 
+            "initiationType": "tender", 
+            "tender": {
+                "documents": [
+                    {
+                        "url": "https://buyandsell.gc.ca/cds/public/2014/03/25/3a76d19e61825db7939e14afaa2002e3/14-2015_itt.pdf", 
+                        "id": "https://buyandsell.gc.ca/cds/public/2014/03/25/3a76d19e61825db7939e14afaa2002e3/14-2015_itt.pdf"
+                    }, 
+                    {
+                        "url": "https://buyandsell.gc.ca/cds/public/2014/03/25/a5d07c1166142b8b2f4183d7a5363fec/14-2015_itt_-_f.pdf", 
+                        "id": "https://buyandsell.gc.ca/cds/public/2014/03/25/a5d07c1166142b8b2f4183d7a5363fec/14-2015_itt_-_f.pdf"
+                    }, 
+                    {
+                        "url": "https://buyandsell.gc.ca/cds/public/2014/04/04/ea5d0f03cfc6ea201b5b6df8794dbb3c/14-2015_itt_amd1.pdf", 
+                        "id": "https://buyandsell.gc.ca/cds/public/2014/04/04/ea5d0f03cfc6ea201b5b6df8794dbb3c/14-2015_itt_amd1.pdf"
+                    }, 
+                    {
+                        "url": "https://buyandsell.gc.ca/cds/public/2014/04/04/ac9afb3b664a28d519062f2b2a4cbceb/14-2015_itt_amd1-f.pdf", 
+                        "id": "https://buyandsell.gc.ca/cds/public/2014/04/04/ac9afb3b664a28d519062f2b2a4cbceb/14-2015_itt_amd1-f.pdf"
+                    }, 
+                    {
+                        "url": "https://buyandsell.gc.ca/cds/public/2014/04/11/f3f3993b4f6f260e057d0cb95f43741d/14-2015_itt_amd2.pdf", 
+                        "id": "https://buyandsell.gc.ca/cds/public/2014/04/11/f3f3993b4f6f260e057d0cb95f43741d/14-2015_itt_amd2.pdf"
+                    }, 
+                    {
+                        "url": "https://buyandsell.gc.ca/cds/public/2014/04/11/69359ba194d3f01f4f13cb9673b85071/14-2015_itt_amd2-f.pdf", 
+                        "id": "https://buyandsell.gc.ca/cds/public/2014/04/11/69359ba194d3f01f4f13cb9673b85071/14-2015_itt_amd2-f.pdf"
+                    }
+                ], 
+                "tenderPeriod": {
+                    "endDate": "2014-04-15T14:00:00.00Z"
+                }, 
+                "items": [
+                    {
+                        "id": "1", 
+                        "classification": {
+                            "scheme": "GSIN", 
+                            "description": "F029: Other Animal Care and Control Services"
+                        }, 
+                        "description": "Canine Control of the Canada Geese (14-2015)"
+                    }
+                ], 
+                "awardCriteriaDetails": null, 
+                "procuringEntity": {
+                    "name": "Agriculture & Agrifood Canada",
+                    "name_fr": "Agriculture & Agrifood Canada"
+                }, 
+                "id": "PW-14-00627094", 
+                "methodRationale": "Open"
+            }, 
+            "tag": ["tender", "oh no"], 
+            "buyer": {
+                "name": "Agriculture & Agrifood Canada"
+            }
+        }, 
+        {
+            "date": "2014-04-04T00:00:00.00Z", 
+            "language": "English", 
+            "id": "Buyandsell.gc.ca-2014-11-07-a76b0dd2-3dc8-4c52-bc36-cd0e42530602", 
+            "ocid": "PW-14-00629344", 
+            "initiationType": "tender", 
+            "tender": {
+                "documents": [
+                    {
+                        "url": "https://buyandsell.gc.ca/cds/public/2014/04/04/cb21d6397174fbba48c92edb694de76f/tender_document_5p404-13181.pdf", 
+                        "id": "https://buyandsell.gc.ca/cds/public/2014/04/04/cb21d6397174fbba48c92edb694de76f/tender_document_5p404-13181.pdf"
+                    }, 
+                    {
+                        "url": "https://buyandsell.gc.ca/cds/public/2014/04/04/370b7a9ab2bdd35086e6caed9b5226f9/fr_tender_document_5p404-13181.pdf", 
+                        "id": "https://buyandsell.gc.ca/cds/public/2014/04/04/370b7a9ab2bdd35086e6caed9b5226f9/fr_tender_document_5p404-13181.pdf"
+                    }
+                ], 
+                "tenderPeriod": {
+                    "endDate": "2014-04-22T00:00:00Z"
+                }, 
+                "items": [
+                    {
+                        "id": "1", 
+                        "classification": {
+                            "scheme": "GSINS", 
+                            "description": "5131BI: Asphalt and Joint Sealing Services, 5131C: Highways, Roads, Railways,  Airfield Runways"
+                        }, 
+                        "description": "Clear Lake Campground Asphalt Paving - Riding Mountain National Park of Canada (5P404-13181)"
+                    }
+                ], 
+                "awardCriteriaDetails": null, 
+                "procuringEntity": {
+                    "name": "Parks Canada"
+                }, 
+                "id": "PW-14-00629344", 
+                "methodRationale": "Open"
+            }, 
+            "tag": ["tender"], 
+            "buyer": {
+                "name": "Parks Canada"
+            }
+        }
+    ], 
+    "uri": "https://github.com/open-contracting/sample-data/blob/master/buyandsell/ocds_data/tender_releases.json.zip", 
+    "license": "http://data.gc.ca/eng/open-government-licence-canada", 
+    "publishedDate": "2014-11-07T00:00:00.00Z",
+    "version": "1.1"
+}

--- a/cove/lib/common.py
+++ b/cove/lib/common.py
@@ -408,6 +408,7 @@ def _load_codelists(codelist_url, unique_files):
     for codelist_file in unique_files:
         try:
             response = requests.get(codelist_url + codelist_file)
+            response.raise_for_status()
             reader = csv.DictReader(line.decode("utf8") for line in response.iter_lines())
             codelists[codelist_file] = {}
             for record in reader:
@@ -416,7 +417,8 @@ def _load_codelists(codelist_url, unique_files):
                 codelists[codelist_file][code] = title
 
         except requests.exceptions.RequestException:
-            raise
+            codelists = {}
+            break
 
     return codelists
 

--- a/cove/lib/common.py
+++ b/cove/lib/common.py
@@ -281,7 +281,7 @@ def _get_schema_deprecated_paths(schema_name, schema_url, obj=None, current_path
     if schema_url:
         obj = get_schema_data(schema_url, schema_name)
 
-    for prop, value in obj['properties'].items():
+    for prop, value in obj.get('properties', {}).items():
         if current_path:
             path = current_path + (prop,)
         else:

--- a/cove/settings.py
+++ b/cove/settings.py
@@ -100,6 +100,14 @@ COVE_CONFIG_BY_NAMESPACE = {
         'cove-360': None,
         'default': None
     },
+    'schema_codelists': {
+        # {version: codelist_dir}
+        'cove-ocds': OrderedDict((
+            ('1.1', 'https://raw.githubusercontent.com/open-contracting/standard/1.1-dev/standard/schema/codelists/'),
+        )),
+        'cove-360': None,
+        'default': None
+    },
     'item_schema_name': {  # Schema url for an individual item e.g. a single release or grant
         'cove-ocds': 'release-schema.json',
         'cove-360': '360-giving-schema.json',

--- a/cove/templates/additional_codelist_values.html
+++ b/cove/templates/additional_codelist_values.html
@@ -13,7 +13,7 @@
    <tbody>
    {% for path, detail in additional_codelist_values.items %}
       <tr>
-        <td>{{detail.field}}</td> <td>{{detail.path}}</td> <td><a href="{{detail.codelist_url}}" >{{detail.codelist}}</td> <td>{{detail.values|join:", "}}</td>
+        <td>{{detail.field}}</td> <td>{{detail.path}}</td> <td><a href="http://datapipes.okfnlabs.org/csv/html/?url={{detail.codelist_url}}" >{{detail.codelist}}</td> <td>{{detail.values|join:", "}}</td>
       </tr>
    {% endfor %}
    </tbody>

--- a/cove/templates/additional_codelist_values.html
+++ b/cove/templates/additional_codelist_values.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% load cove_tags %}
+
+<table class="table">
+   <thead>
+     <tr> 
+       <th>{% trans 'Field' %}</th> 
+       <th>{% trans 'Path to Field' %}</th> 
+       <th>{% trans 'Codelist' %}</th> 
+       <th>{% trans 'Additional Values Used' %}</th>
+     </tr>
+   </thead>
+   <tbody>
+   {% for path, detail in additional_codelist_values.items %}
+      <tr>
+        <td>{{detail.field}}</td> <td>{{detail.path}}</td> <td><a href="{{detail.codelist_url}}" >{{detail.codelist}}</td> <td>{{detail.values|join:", "}}</td>
+      </tr>
+   {% endfor %}
+   </tbody>
+</table>

--- a/cove/templates/explore_ocds_base.html
+++ b/cove/templates/explore_ocds_base.html
@@ -182,6 +182,22 @@
   </div>
 {% endif %}
 
+{% if additional_closed_codelist_values %}
+    <a name="additional-fields" class="anchor"></a>
+    <div class="panel panel-danger">
+      <div id="additional-fields-panel" class="panel-heading pointer" role="region" aria-expanded="true" aria-controls="additionalClosedCodelist" data-toggle="collapse" data-target="#additionalClosedCodelist">
+        <h4 class="panel-title">
+          <span class="our-title"><span class="glyphicon glyphicon-collapse-up"></span>{% trans 'Codelist Validation Errors' %}</span>
+        </h4>
+      </div>
+      <div id="additionalClosedCodelist" class="collapse in">
+        {% with additional_codelist_values=additional_closed_codelist_values %}
+        {% include "additional_codelist_values.html" %}
+        {% endwith%}
+      </div>
+    </div>
+{% endif %}
+
 
 
 {% if data_only %}
@@ -198,28 +214,13 @@
     </div>
 {% endif %}
 
-{% if additional_closed_codelist_values %}
-    <a name="additional-fields" class="anchor"></a>
-    <div class="panel panel-danger">
-      <div id="additional-fields-panel" class="panel-heading pointer" role="region" aria-expanded="true" aria-controls="additionalClosedCodelist" data-toggle="collapse" data-target="#additionalClosedCodelist">
-        <h4 class="panel-title">
-          <span class="our-title"><span class="glyphicon glyphicon-collapse-up"></span>{% trans 'Additional Closed Codelist Values' %}</span>
-        </h4>
-      </div>
-      <div id="additionalClosedCodelist" class="collapse in">
-        {% with additional_codelist_values=additional_closed_codelist_values %}
-        {% include "additional_codelist_values.html" %}
-        {% endwith%}
-      </div>
-    </div>
-{% endif %}
 
 {% if additional_open_codelist_values %}
     <a name="additional-fields" class="anchor"></a>
     <div class="panel panel-warning">
       <div id="additional-fields-panel" class="panel-heading pointer" role="region" aria-expanded="true" aria-controls="additionalOpenCodelist" data-toggle="collapse" data-target="#additionalOpenCodelist">
         <h4 class="panel-title">
-          <span class="our-title"><span class="glyphicon glyphicon-collapse-up"></span>{% trans 'Additional Open Codelist Values' %}</span>
+          <span class="our-title"><span class="glyphicon glyphicon-collapse-up"></span>{% trans 'Additional Codelist Values' %}</span>
         </h4>
       </div>
       <div id="additionalOpenCodelist" class="collapse in">

--- a/cove/templates/explore_ocds_base.html
+++ b/cove/templates/explore_ocds_base.html
@@ -198,6 +198,39 @@
     </div>
 {% endif %}
 
+{% if additional_closed_codelist_values %}
+    <a name="additional-fields" class="anchor"></a>
+    <div class="panel panel-danger">
+      <div id="additional-fields-panel" class="panel-heading pointer" role="region" aria-expanded="true" aria-controls="additionalClosedCodelist" data-toggle="collapse" data-target="#additionalClosedCodelist">
+        <h4 class="panel-title">
+          <span class="our-title"><span class="glyphicon glyphicon-collapse-up"></span>{% trans 'Additional Closed Codelist Values' %}</span>
+        </h4>
+      </div>
+      <div id="additionalClosedCodelist" class="collapse in">
+        {% with additional_codelist_values=additional_closed_codelist_values %}
+        {% include "additional_codelist_values.html" %}
+        {% endwith%}
+      </div>
+    </div>
+{% endif %}
+
+{% if additional_open_codelist_values %}
+    <a name="additional-fields" class="anchor"></a>
+    <div class="panel panel-warning">
+      <div id="additional-fields-panel" class="panel-heading pointer" role="region" aria-expanded="true" aria-controls="additionalOpenCodelist" data-toggle="collapse" data-target="#additionalOpenCodelist">
+        <h4 class="panel-title">
+          <span class="our-title"><span class="glyphicon glyphicon-collapse-up"></span>{% trans 'Additional Open Codelist Values' %}</span>
+        </h4>
+      </div>
+      <div id="additionalOpenCodelist" class="collapse in">
+        {% with additional_codelist_values=additional_open_codelist_values %}
+        {% include "additional_codelist_values.html" %}
+        {% endwith%}
+      </div>
+    </div>
+{% endif %}
+
+
 {% if deprecated_fields %}
     <a name="deprecated-fields" class="anchor"></a>
     <div class="panel panel-warning">

--- a/cove/templates/explore_ocds_base.html
+++ b/cove/templates/explore_ocds_base.html
@@ -191,9 +191,13 @@
         </h4>
       </div>
       <div id="additionalClosedCodelist" class="collapse in">
+        <div class="panel-body">
+          The fields below use closed codelists. When using these fields, you <strong> must </strong> use one of the pre-defined codelist values. If you use a value that is not on the relevant codelist, your data will not pass validation.
         {% with additional_codelist_values=additional_closed_codelist_values %}
         {% include "additional_codelist_values.html" %}
         {% endwith%}
+          You may need to create a mapping between your local codes and the OCDS closed codelists to address these errors. In most cases, there will be a ‘detail’ field where you can also include your local codes. If you have already completed a mapping, please review the spelling and capitalisation used in these closed codelist fields.
+        </div>
       </div>
     </div>
 {% endif %}
@@ -223,10 +227,14 @@
           <span class="our-title"><span class="glyphicon glyphicon-collapse-up"></span>{% trans 'Additional Codelist Values' %}</span>
         </h4>
       </div>
-      <div id="additionalOpenCodelist" class="collapse in">
-        {% with additional_codelist_values=additional_open_codelist_values %}
-        {% include "additional_codelist_values.html" %}
-        {% endwith%}
+      <div class="panel-body">
+        Your data contains a number of fields that use an open codelist. You should use values from the codelist whenever possible, but if the codelist does not provide the values you need, you are permitted to add additional values. The values below do not appear in the codelist; you should check that you intended these as additional values.
+        <div id="additionalOpenCodelist" class="collapse in">
+          {% with additional_codelist_values=additional_open_codelist_values %}
+          {% include "additional_codelist_values.html" %}
+          {% endwith%}
+        </div>
+        Make sure your list the definition of any additional codelist values you include within your <a href="http://standard.open-contracting.org/latest/en/implementation/publication_policy/">publication policy</a>, and if you believe they should be added as recommended values in the open codelist, please suggest this via the <a href="https://github.com/open-contracting/standard/issues/new"> OCDS issue tracker.</a>
       </div>
     </div>
 {% endif %}

--- a/cove/tests.py
+++ b/cove/tests.py
@@ -538,3 +538,32 @@ def test_data_supplied_schema_version(client):
     assert resp.status_code == 200
     assert resp.context['version_used'] == '1.1'
     assert SuppliedData.objects.get(id=data.id).schema_version == '1.1'
+
+
+def test_get_additional_codelist_values():
+    from django.conf import settings
+    with open(os.path.join('cove', 'fixtures', 'tenders_releases_2_releases_codelists.json')) as fp:
+        json_data_w_additial_codelists = json.load(fp)
+
+    schema_url = settings.COVE_CONFIG_BY_NAMESPACE['schema_version_choices']['cove-ocds']['1.1'][1]
+    codelist_url = settings.COVE_CONFIG_BY_NAMESPACE['schema_codelists']['cove-ocds']['1.1']
+    schema_name = 'release-package-schema.json'
+    additional_codelist_values = c.get_additional_codelist_values(schema_name, schema_url, codelist_url, json_data_w_additial_codelists)
+
+    assert additional_codelist_values == {
+        ('releases', 'tag'): {
+            'codelist': 'releaseTag.csv',
+            'codelist_url': 'https://raw.githubusercontent.com/open-contracting/standard/1.1-dev/standard/schema/codelists/releaseTag.csv',
+            'field': 'tag',
+            'isopen': False,
+            'path': 'releases',
+            'values': {'oh no'}
+        },
+        ('releases', 'tender', 'items', 'classification', 'scheme'): {
+            'codelist': 'itemClassificationScheme.csv',
+            'codelist_url': 'https://raw.githubusercontent.com/open-contracting/standard/1.1-dev/standard/schema/codelists/itemClassificationScheme.csv',
+            'field': 'scheme',
+            'isopen': True,
+            'path': 'releases/tender/items/classification',
+            'values': {'GSINS'}}
+    }

--- a/cove/views.py
+++ b/cove/views.py
@@ -120,9 +120,13 @@ def explore(request, pk):
     else:
         schema_url = request.cove_config['schema_url']
 
+    validation_errors_path = os.path.join(data.upload_dir(), 'validation_errors-2.json')
+
     if 'version' in request.POST and request.POST['version'] != data.schema_version:
         schema_user_choice = request.POST.get('version')
         if schema_user_choice in schema_version_choices:
+            if os.path.exists(validation_errors_path):
+                os.remove(validation_errors_path)
             schema_version = schema_user_choice
             schema_url = schema_version_choices[schema_user_choice][1]
             replace_conversion = True
@@ -205,8 +209,7 @@ def explore(request, pk):
         with open(os.path.join(data.upload_dir(), 'heading_source_map.json')) as heading_source_map_fp:
             heading_source_map = json.load(heading_source_map_fp)
 
-    validation_errors_path = os.path.join(data.upload_dir(), 'validation_errors-2.json')
-    if os.path.exists(validation_errors_path) and not replace_conversion:
+    if os.path.exists(validation_errors_path):
         with open(validation_errors_path) as validiation_error_fp:
             validation_errors = json.load(validiation_error_fp)
     else:

--- a/cove/views.py
+++ b/cove/views.py
@@ -231,6 +231,9 @@ def explore(request, pk):
             view = 'explore_ocds-record.html'
         else:
             context['releases_aggregates'] = ocds.get_releases_aggregates(json_data, ignore_errors=bool(validation_errors))
+            additional_codelist_values = common.get_additional_codelist_values(schema_name, schema_url, request.cove_config['schema_codelists'].get(schema_version), json_data)
+            context['additional_open_codelist_values'] = {key: value for key, value in additional_codelist_values.items() if value['isopen']}
+            context['additional_closed_codelist_values'] = {key: value for key, value in additional_codelist_values.items() if not value['isopen']}
             view = 'explore_ocds-release.html'
     elif request.current_app == 'cove-360':
         context['grants_aggregates'] = threesixtygiving.get_grants_aggregates(json_data)

--- a/fts/tests.py
+++ b/fts/tests.py
@@ -207,6 +207,8 @@ def test_accordion(server_url, browser, prefix):
                                                   'Validation Errors',
                                                   "'id' is missing but required",
                                                   "Invalid 'uri' found"], True),
+    ('tenders_releases_2_releases_codelists.json', ['oh no',
+                                                    'GSINS'], True),
     # Test UTF-8 support
     ('utf8.json', 'Convert', True),
     # But we expect to see an error message if a file is not well formed JSON at all


### PR DESCRIPTION
Looks up codelists from github and caches them.
Adds two new boxes to frontend one for closed and one for open
codelists.
Removes validation results for enums that also have codelists. This was
a bit messy as it was hard to get out correct properties from jsonschema
when dealing with arrays of enums.