### PR TITLE
[#762] Only include raven in installed apps if SENTRY_DSN is set

### DIFF
--- a/cove/settings.py
+++ b/cove/settings.py
@@ -89,10 +89,12 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'bootstrap3',
-    'raven.contrib.django.raven_compat',
     'cove',
     'cove.input',
 )
+
+if env('SENTRY_DSN'):
+    INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
 
 if env('DEBUG_TOOLBAR'):
     INSTALLED_APPS += ('debug_toolbar',)


### PR DESCRIPTION
This makes sure there's no output to the expire_files command, which
would laed to uncesseary cron notifications.