### PR TITLE
make sample data link absolute

### DIFF
--- a/cove_ocds/templates/cove_ocds/base.html
+++ b/cove_ocds/templates/cove_ocds/base.html
@@ -128,7 +128,7 @@
         <p> {% blocktrans %}The application works with both <a href="http://standard.open-contracting.org/latest/en/getting_started/releases_and_records/">'release' and 'record'</a> OCDS documents that conform to the <a href="http://standard.open-contracting.org/">Open Data Contracting Standard</a> {%endblocktrans%} </p>
         <p> {% blocktrans %}If your data passes basic validation checks, the tool will then present a report on data quality, and information about the contents of your file. It will also offer alternative copies of the data for download. {%endblocktrans%} </p>
         <p> {% blocktrans %}Data is stored for 7 days at a randomly generated URL. You can share this link with others to support discussion of data quality.  {%endblocktrans%} </p>
-        <p> {% blocktrans %}To preview how the validator works, try <a href="http://standard.open-contracting.org/validator/?source_url=https://raw.githubusercontent.com/open-contracting/sample-data/master/fictional-example/ocds-213czf-000-00001-02-tender.json"> loading some sample data. </a>{% endblocktrans%} </p>
+        <p> {% blocktrans %}To preview how the validator works, try <a href="/validator/?source_url=https://raw.githubusercontent.com/open-contracting/sample-data/master/fictional-example/ocds-213czf-000-00001-02-tender.json"> loading some sample data. </a>{% endblocktrans%} </p>
       </div>
     </div>
   </div>

--- a/cove_ocds/templates/cove_ocds/base.html
+++ b/cove_ocds/templates/cove_ocds/base.html
@@ -128,7 +128,7 @@
         <p> {% blocktrans %}The application works with both <a href="http://standard.open-contracting.org/latest/en/getting_started/releases_and_records/">'release' and 'record'</a> OCDS documents that conform to the <a href="http://standard.open-contracting.org/">Open Data Contracting Standard</a> {%endblocktrans%} </p>
         <p> {% blocktrans %}If your data passes basic validation checks, the tool will then present a report on data quality, and information about the contents of your file. It will also offer alternative copies of the data for download. {%endblocktrans%} </p>
         <p> {% blocktrans %}Data is stored for 7 days at a randomly generated URL. You can share this link with others to support discussion of data quality.  {%endblocktrans%} </p>
-        <p> {% blocktrans %}To preview how the validator works, try <a href="?source_url=https://raw.githubusercontent.com/open-contracting/sample-data/master/fictional-example/ocds-213czf-000-00001-02-tender.json"> loading some sample data. </a>{% endblocktrans%} </p>
+        <p> {% blocktrans %}To preview how the validator works, try <a href="http://standard.open-contracting.org/validator/?source_url=https://raw.githubusercontent.com/open-contracting/sample-data/master/fictional-example/ocds-213czf-000-00001-02-tender.json"> loading some sample data. </a>{% endblocktrans%} </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
the relative link was breaking on the "Sorry we can't process that data" page ([example](http://standard.open-contracting.org/validator/data/af449fbb-f88c-49d9-84c7-abcdb40cefe5))