### PR TITLE
[#940] Update flatten-tool

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 pip
 Django<1.12
 #^^ rq.filter: <1.12
--e git+https://github.com/OpenDataServices/flatten-tool.git@a62361f74f8246cc457e7de5e9641724800b25b0#egg=flattentool
+-e git+https://github.com/OpenDataServices/flatten-tool.git@e700b32932232660bed95fa3bcf8936bb2e351a6#egg=flattentool
 django-bootstrap3
 django-debug-toolbar
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip==9.0.3
 Django==1.11.11 # rq.filter: <1.12
--e git+https://github.com/OpenDataServices/flatten-tool.git@a62361f74f8246cc457e7de5e9641724800b25b0#egg=flattentool
+-e git+https://github.com/OpenDataServices/flatten-tool.git@e700b32932232660bed95fa3bcf8936bb2e351a6#egg=flattentool
 django-bootstrap3==9.1.0
 django-debug-toolbar==1.9.1
 requests==2.18.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 pip==9.0.3
 Django==1.11.11 # rq.filter: <1.12
--e git+https://github.com/OpenDataServices/flatten-tool.git@a62361f74f8246cc457e7de5e9641724800b25b0#egg=flattentool
+-e git+https://github.com/OpenDataServices/flatten-tool.git@e700b32932232660bed95fa3bcf8936bb2e351a6#egg=flattentool
 django-bootstrap3==9.1.0
 django-debug-toolbar==1.9.1
 requests==2.18.4


### PR DESCRIPTION
#940

Only change to behaviour is to remove duplicate None warnings
https://github.com/OpenDataServices/flatten-tool/pull/199

This is mostly a duplicate of
https://github.com/OpenDataServices/cove/commit/89e5a4779c7fbf9415f1aabc4bc934a227696326,
but that failed to update `requirements.in`. This meant the changes to
`requirements.txt` and `requirements_dev.txt` were subsequently accidentally clobbered.