### PR TITLE
Add T&Cs for review of submitted data to assess website operation

### DIFF
--- a/cove/templates/terms.html
+++ b/cove/templates/terms.html
@@ -185,7 +185,7 @@
 
   <p>Please do not submit any non-public personal data to this application.</p>
 
-  <p>We do not make use of any of the data within the files for purposes other than to create reports for you about the data you have submitted.</p>
+  <p>We do not make use of any of the data within the files for purposes other than to create reports for you about the data you have submitted and to review the operation and output of the website.</p>
 
   <p>We do create and store metadata about your use of the application, and about the files/data that you have uploaded in order to monitor how the application is being used.</p>
 


### PR DESCRIPTION
This is a duplicate of
https://github.com/OpenDataServices/cove/commit/4c075c3d440d08792796616bdc28ec35b48a569a#diff-e793cd92ba35eaa07fd8126406fd764c

This got removed from the OCDS T&Cs by accident during GDPR updates.

This commit also adds it to the T&Cs for 360Giving and IATI CoVEs.