### PR TITLE
Rename OCDS Validator -> Data Review Tool

### DIFF
--- a/cove_ocds/settings.py
+++ b/cove_ocds/settings.py
@@ -33,8 +33,8 @@ ROOT_URLCONF = 'cove_ocds.urls'
 COVE_CONFIG = {
     'app_name': 'cove_ocds',
     'app_base_template': 'cove_ocds/base.html',
-    'app_verbose_name': 'Open Contracting Data Standard Validator',
-    'app_strapline': 'Validate and Explore your data.',
+    'app_verbose_name': 'Open Contracting Data Review Tool',
+    'app_strapline': 'Review your OCDS data.',
     'schema_name': {'release': 'release-package-schema.json', 'record': 'record-package-schema.json'},
     'schema_item_name': 'release-schema.json',
     'schema_host': None,

--- a/cove_ocds/templates/cove_ocds/base.html
+++ b/cove_ocds/templates/cove_ocds/base.html
@@ -104,7 +104,7 @@
         <ul>
           <li> {% blocktrans %}Check that your OCDS data complies with the <a href="http://standard.open-contracting.org/latest/en/schema/">schema</a>{%endblocktrans%}</li>
           <li> {% blocktrans %}Inspect key contents of your data to check data quality{%endblocktrans%} </li>
-          <li> {% blocktrans %}Access your data in different formats (spreadsheet and JSON) to support further data validation.{%endblocktrans%} </li>
+          <li> {% blocktrans %}Access your data in different formats (spreadsheet and JSON) to support further review.{%endblocktrans%} </li>
         </ul>
         <br/>
       </div>
@@ -119,7 +119,7 @@
     <div class="panel panel-default">
       <div class="panel-body">
 
-        <h1 class="heading-in-panel"> <small> {% blocktrans %}Using the validator{%endblocktrans%}</small> </h1>
+        <h1 class="heading-in-panel"> <small> {% blocktrans %}Using the data review tool{%endblocktrans%}</small> </h1>
         <p> {% blocktrans %}You can upload, paste or provide a link to data published using the <a href="http://standard.open-contracting.org/">Open Contracting Data Standard</a>. This can be:{%endblocktrans%} </p>
 
         <ul>
@@ -128,9 +128,9 @@
         </ul>
         <p> {% blocktrans %}Supported encodings are UTF-8 for JSON and UTF-8, Windows-1252 and ISO-8859-1 for CSV.{% endblocktrans%} </p>
         <p> {% blocktrans %}The application works with both <a href="http://standard.open-contracting.org/latest/en/getting_started/releases_and_records/">'release' and 'record'</a> OCDS documents that conform to the <a href="http://standard.open-contracting.org/">Open Data Contracting Standard</a> {%endblocktrans%} </p>
-        <p> {% blocktrans %}If your data passes basic validation checks, the tool will then present a report on data quality, and information about the contents of your file. It will also offer alternative copies of the data for download. {%endblocktrans%} </p>
+        <p> {% blocktrans %}If your data passes basic schema validation checks, the tool will then present a report on data quality, and information about the contents of your file. It will also offer alternative copies of the data for download. {%endblocktrans%} </p>
         <p> {% blocktrans %}Data is stored for 7 days at a randomly generated URL. You can share this link with others to support discussion of data quality.  {%endblocktrans%} </p>
-        <p> {% blocktrans %}To preview how the validator works, try <a href="/validator/?source_url=https://raw.githubusercontent.com/open-contracting/sample-data/master/fictional-example/1.1/ocds-213czf-000-00001-02-tender.json"> loading some sample data. </a>{% endblocktrans%} </p>
+        <p> {% blocktrans %}To preview how the data review tool works, try <a href="/validator/?source_url=https://raw.githubusercontent.com/open-contracting/sample-data/master/fictional-example/1.1/ocds-213czf-000-00001-02-tender.json"> loading some sample data. </a>{% endblocktrans%} </p>
       </div>
     </div>
   </div>

--- a/cove_ocds/templates/cove_ocds/base.html
+++ b/cove_ocds/templates/cove_ocds/base.html
@@ -52,7 +52,7 @@
       </div><!--row-->
       <div class="row">
         <div class="col-xs-7">
-          {% block h1 %}<h1 class="application-name"><a href="{% url 'index' %}">{% blocktrans %} Data <span> Standard </span> Validator{% endblocktrans %} </a></h1> <h2 class="beta"><small>beta</small></h2>{% endblock %}
+          {% block h1 %}<h1 class="application-name"><a href="{% url 'index' %}">{% blocktrans %} Data <span> Review </span> Tool{% endblocktrans %} </a></h1> <h2 class="beta"><small>beta</small></h2>{% endblock %}
         </div><!--col-md-8-->
         <div class="col-xs-5">
           <a href="http://standard.open-contracting.org"><h3 class="docs-link pull-right">{% blocktrans %} Standard Documentation {% endblocktrans %}</h3></a>
@@ -99,11 +99,11 @@
     <div class="panel panel-default">
       <div class="panel-body">
 
-        <h1 class="heading-in-panel"> <small>{% blocktrans %}Validate and Explore{%endblocktrans%}</small> </h1>
+        <h1 class="heading-in-panel"> <small>{% blocktrans %}Check and Review{%endblocktrans%}</small> </h1>
         <p> {% blocktrans %}This tool helps you to:{%endblocktrans%} </p>
         <ul>
           <li> {% blocktrans %}Check that your OCDS data complies with the <a href="http://standard.open-contracting.org/latest/en/schema/">schema</a>{%endblocktrans%}</li>
-          <li> {% blocktrans %}Inspect key contents of your data to check data quality{%endblocktrans%} </li>
+          <li> {% blocktrans %}Inspect key contents of your data to review data quality{%endblocktrans%} </li>
           <li> {% blocktrans %}Access your data in different formats (spreadsheet and JSON) to support further review.{%endblocktrans%} </li>
         </ul>
         <br/>

--- a/cove_ocds/templates/cove_ocds/explore_base.html
+++ b/cove_ocds/templates/cove_ocds/explore_base.html
@@ -20,12 +20,12 @@
       <div class="panel-body">
         {% if unrecognized_version_data %}
           <div class="bg-danger in-panel-warning">
-            <small><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span> &nbsp;Your data specifies a version <strong>{{unrecognized_version_data}}</strong> which is not recognised. For that reason, it's been validated against the current default version.</small>
+            <small><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span> &nbsp;Your data specifies a version <strong>{{unrecognized_version_data}}</strong> which is not recognised. For that reason, it's been checked against the current default version.</small>
           </div>
         {% endif %}
-        <p>This data has been checked against <a href="{{ schema_url }}">OCDS {% if releases %}release {% endif %}{% if records %}record {% endif %}package schema version {{ version_used_display }}</a>. You can choose a different version of the schema to validate and explore your data.</p>
+        <p>This data has been checked against <a href="{{ schema_url }}">OCDS {% if releases %}release {% endif %}{% if records %}record {% endif %}package schema version {{ version_used_display }}</a>. You can choose a different version of the schema to check and explore your data.</p>
         <br>
-        <strong>Validate and explore same data against a different version of the schema</strong>
+        <strong>Check and explore same data against a different version of the schema</strong>
         <div class="ttip">
           <sup><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></sup>
           <span class="ttiptext">Switching the schema version will result in changes to CoVE output and conversions. If you revisit or share this URL, the lastest version selected will be used to check your data</span>
@@ -184,7 +184,7 @@
         {% endif %}
         <span class="glyphicon glyphicon-download" aria-hidden="true"></span> <a href="{{extensions.extended_schema_url}}"> &nbsp;Get a copy of the schema with extension patches applied</a>
       {% else %}
-        <p>None of the extensions above could be applied. Your data has been validated against a schema with no extensions.</p>
+        <p>None of the extensions above could be applied. Your data has been checked against a schema with no extensions.</p>
       {% endif %}
 
     </div>
@@ -202,7 +202,7 @@
     </div>
     <div class="panel-body">
       {% if file_type == 'xlsx' or file_type == 'csv' %}
-        <p class="explanation">In order to validate your data we need to convert it. During that conversion we found the following issues:</p>
+        <p class="explanation">In order to check your data we need to convert it. During that conversion we found the following issues:</p>
       {% endif %}
       <ul>
         {% for warning_message in conversion_warning_messages %}
@@ -224,7 +224,7 @@
     </div>
     <div class="panel-body">
     {% if file_type == 'xlsx' or file_type == 'csv' %}
-      <p class="explanation">In order to validate your data we need to convert it. During that conversion we found the following issues:</p>
+      <p class="explanation">In order to check your data we need to convert it. During that conversion we found the following issues:</p>
     {% endif %}
     <ul>
       {% for warning_message in conversion_warning_messages_titles %}
@@ -310,7 +310,7 @@
       </div>
       <div id="additionalClosedCodelist" class="collapse in">
         <div class="panel-body">
-          The fields below use closed codelists. When using these fields, you <strong> must </strong> use one of the pre-defined codelist values. If you use a value that is not on the relevant codelist, your data will not pass validation. Where you see + or - this indicates that the codelist has been modified with these additions (+) or subtractions (-) by one or more extensions.
+          The fields below use closed codelists. When using these fields, you <strong> must </strong> use one of the pre-defined codelist values. If you use a value that is not on the relevant codelist, your data will not pass schema validation checks. Where you see + or - this indicates that the codelist has been modified with these additions (+) or subtractions (-) by one or more extensions.
           {% with additional_codelist_values=additional_closed_codelist_values %}
           <div>{% include "additional_codelist_values.html" %}</div>
           {% endwith %}

--- a/cove_ocds/templates/cove_ocds/explore_release.html
+++ b/cove_ocds/templates/cove_ocds/explore_release.html
@@ -21,7 +21,7 @@
           <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>{% trans "Passed " %} 
         {% endif %}
         {% blocktrans %}validation against {% endblocktrans %}<a href="{{ schema_url }}">OCDS release package schema version {{ version_used_display }}</a>.
-        {% if validation_errors %}<br/>{% blocktrans %}See <a href="#validation-errors">Validation Errors</a> below.{% endblocktrans %}{% endif %}
+        {% if validation_errors %}<br/>{% blocktrans %}See <a href="#validation-errors">Schema validation Errors</a> below.{% endblocktrans %}{% endif %}
         </div>
         {% if extensions and extensions.invalid_extension %}
         <div class="message">

--- a/cove_ocds/tests_functional.py
+++ b/cove_ocds/tests_functional.py
@@ -80,8 +80,8 @@ def test_footer_ocds(server_url, browser, link_text, expected_text, css_selector
 
 def test_index_page_ocds(server_url, browser):
     browser.get(server_url)
-    assert 'Data Standard Validator' in browser.find_element_by_tag_name('body').text
-    assert 'Using the validator' in browser.find_element_by_tag_name('body').text
+    assert 'Data Review Tool' in browser.find_element_by_tag_name('body').text
+    assert 'Using the data review tool' in browser.find_element_by_tag_name('body').text
     assert "'release'" in browser.find_element_by_tag_name('body').text
     assert "'record'" in browser.find_element_by_tag_name('body').text
 
@@ -329,7 +329,7 @@ def check_url_input_result_page(server_url, browser, httpserver, source_filename
     for text in not_expected_text:
         assert text not in body_text
 
-    assert 'Data Standard Validator' in browser.find_element_by_tag_name('body').text
+    assert 'Data Review Tool' in browser.find_element_by_tag_name('body').text
     # assert 'Release Table' in browser.find_element_by_tag_name('body').text
 
     if conversion_successful:


### PR DESCRIPTION
We have agreed to rename the OCDS Validator to 'Data Review Tool'. This fits with discussions in internal [CRM issue 2944](https://crm.open-contracting.org/issues/2944#note-1).

I have had a first pass at updating the templates to do this [in this branch](https://github.com/OpenDataServices/cove/tree/ocds-data-review-tool) - and using this PR to highlight the changes we could/should make. 

This also addresses elements of #884

* I have changed terminology about running validations to 'running checks'.
* I have kept language of validation where we are validating against the schema to make clear that we are 'checking against the schema' or 'validating against the schema'.

I've tried to update tests, but I've not been able to run the tests. 

Before going live this will need translation of updated terms. 