### PR TITLE
Enable Flatten-Tool option remove_empty_schema_columns for 360 and IATI.

### DIFF
--- a/cove/lib/converters.py
+++ b/cove/lib/converters.py
@@ -128,7 +128,8 @@ def convert_json(upload_dir, upload_url, file_name, schema_url=None, replace=Fal
         main_sheet_name=config['root_list_path'],
         root_list_path=config['root_list_path'],
         root_id=config['root_id'],
-        schema=schema_url
+        schema=schema_url,
+        remove_empty_schema_columns=True
     )
 
     if xml:


### PR DESCRIPTION
This is already enabled for OCDS in it's library - at https://github.com/open-contracting/lib-cove-ocds/commit/3c33bd05c3495cdc5cb4de4cba446d628e1a3674

See https://opendataservices.plan.io/issues/16915