### PR TITLE
These packages are no longer in cove (fixes #1102)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     version='0.0.0',
     author='Open Data Services',
     author_email='code@opendataservices.coop',
-    packages=['cove', 'cove.input', 'cove.dataload', 'cove.lib'],
     scripts=['manage.py'],
     url='https://github.com/OpenDataServices/cove',
     description='',


### PR DESCRIPTION
Though tbh I'm not sure why `cove_360`, `cove_ocds` and `cove_iati` aren't listed here, but they never were, so..