### PR TITLE
Only embedded codelists are checked

### DIFF
--- a/cove_iati/templates/cove_iati/explore.html
+++ b/cove_iati/templates/cove_iati/explore.html
@@ -146,9 +146,9 @@
       <div class="panel-body">
         <p class="explanation">
         {% if invalid_embedded_codelist_values %}
-            {% trans "Sorry your data contains values in codelists that do not exist in the standard" %}
+            {% trans "Sorry your data contains values in embedded codelists that do not exist in the standard" %}
         {% else %}
-          {% trans "Congratulations! Your codelist values are all valid" %}
+          {% trans "Congratulations! Your embedded codelist values are all valid" %}
         {% endif %}
         </p>
         <div class="explore-help"></div>


### PR DESCRIPTION
This tweaks the copy to avoid the suggestion that non-embedded codelist
values are checked, too.

Fixes #1124.