### PR TITLE
Add back mark_safe in headings when added in AdditionalTest

### DIFF
--- a/cove_360/lib/threesixtygiving.py
+++ b/cove_360/lib/threesixtygiving.py
@@ -399,7 +399,7 @@ class RecipientOrg360GPrefix(AdditionalTest):
         except KeyError:
             pass
 
-        self.heading = self.format_heading_count(self.check_text['heading'])
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading']))
         self.message = self.check_text['message'][self.grants_percentage]
 
 
@@ -427,7 +427,7 @@ class FundingOrg360GPrefix(AdditionalTest):
         except KeyError:
             pass
 
-        self.heading = self.format_heading_count(self.check_text['heading'])
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading']))
         self.message = self.check_text['message'][self.grants_percentage]
 
 
@@ -463,7 +463,7 @@ class RecipientOrgUnrecognisedPrefix(AdditionalTest):
         except KeyError:
             pass
 
-        self.heading = self.format_heading_count(self.check_text['heading'])
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading']))
         self.message = self.check_text['message'][self.grants_percentage]
 
 
@@ -500,7 +500,7 @@ class FundingOrgUnrecognisedPrefix(AdditionalTest):
         except KeyError:
             pass
 
-        self.heading = self.format_heading_count(self.check_text['heading'])
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading']))
         self.message = self.check_text['message'][self.grants_percentage]
 
 
@@ -539,7 +539,7 @@ class RecipientOrgCharityNumber(AdditionalTest):
         except KeyError:
             pass
 
-        self.heading = self.format_heading_count(self.check_text['heading'])
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading']))
         self.message = self.check_text['message'][self.grants_percentage]
 
 
@@ -578,7 +578,7 @@ class RecipientOrgCompanyNumber(AdditionalTest):
         except KeyError:
             pass
 
-        self.heading = self.format_heading_count(self.check_text['heading'])
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading']))
         self.message = mark_safe(self.check_text['message'][self.grants_percentage])
 
 
@@ -612,7 +612,7 @@ class NoRecipientOrgCompanyCharityNumber(AdditionalTest):
         except KeyError:
             pass
 
-        self.heading = self.format_heading_count(self.check_text['heading'], verb="do")
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading'], verb="do"))
         self.message = self.check_text['message'][self.grants_percentage]
 
 
@@ -744,7 +744,7 @@ class NoGrantProgramme(AdditionalTest):
             self.count += 1
             self.json_locations.append(path_prefix + '/id')
 
-        self.heading = self.format_heading_count(self.check_text['heading'], verb='do')
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading'], verb='do'))
         self.message = mark_safe(self.check_text['message'][self.grants_percentage])
 
 
@@ -877,7 +877,7 @@ class NoLastModified(AdditionalTest):
             self.count += 1
             self.json_locations.append(path_prefix + '/id')
 
-        self.heading = self.format_heading_count(self.check_text['heading'], verb='do')
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading'], verb='do'))
         self.message = mark_safe(self.check_text['message'][self.grants_percentage])
 
 
@@ -903,7 +903,7 @@ class NoDataSource(AdditionalTest):
             self.count += 1
             self.json_locations.append(path_prefix + '/id')
 
-        self.heading = self.format_heading_count(self.check_text['heading'], verb='do')
+        self.heading = mark_safe(self.format_heading_count(self.check_text['heading'], verb='do'))
         self.message = mark_safe(self.check_text['message'][self.grants_percentage])
 
 


### PR DESCRIPTION
It looks like that mark_safe needs to be in both places, inside `check_text` and in `AdditionalTest` to work everywhere where is used. In this PR I have added it back where it is setup for AdditionalTest