### PR TITLE
Update openpyxl to 2.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ jdcal==1.3
 jsonref==0.1
 LEPL==5.1.3
 lxml==4.3.0
-openpyxl==2.6.1
+openpyxl==2.6.2
 
 pytz==2018.3
 schema==0.6.7

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -60,7 +60,7 @@ lxml==4.3.0
 MarkupSafe==1.0
 mccabe==0.6.1
 more-itertools==4.1.0
-openpyxl==2.6.1
+openpyxl==2.6.2
 packaging==17.1
 
 pluggy==0.6.0


### PR DESCRIPTION
Fixes issues with hyperlinks in merged cells.
https://bitbucket.org/openpyxl/openpyxl/pull-requests/327/attributeerror-mergedcell-object-attribute/diff
