### PR TITLE
Fix typo, fixes #1092

### DIFF
--- a/cove_ocds/templates/cove_ocds/explore_release.html
+++ b/cove_ocds/templates/cove_ocds/explore_release.html
@@ -61,7 +61,7 @@
              {% if extensions and extensions.is_extended_schema %}
                 <li><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
                   {% with n_invalid=extensions.invalid_extension.keys|length %}
-                    {% trans "This file applies" %}{% blocktrans count count=extensions.extensions.keys|length|subtract:n_invalid %}{{count}} valid <a href="#schema-extensions">extension</a>{% plural %} {{count}} valid <a href="#schema-extensions">extensions</a> {% endblocktrans %} {% trans "to the schema" %}.
+                    {% trans "This file applies" %} {% blocktrans count count=extensions.extensions.keys|length|subtract:n_invalid %}{{count}} valid <a href="#schema-extensions">extension</a>{% plural %} {{count}} valid <a href="#schema-extensions">extensions</a> {% endblocktrans %} {% trans "to the schema" %}.
                   {% endwith %}
                 </li>
              {% endif %}


### PR DESCRIPTION
Adds a space to the template. Transifex did not need to be invoked because the missing space was added outside of a msg string!

![Screenshot at 2019-11-08 19-43-59](https://user-images.githubusercontent.com/466229/68498750-56869d00-0260-11ea-9fd3-44501a240018.png)
