### PR TITLE
cove360: templates: explore.html: display metadata 'issued on'

### DIFF
--- a/cove_360/templates/cove_360/explore.html
+++ b/cove_360/templates/cove_360/explore.html
@@ -93,7 +93,7 @@
                  {% blocktrans with start_date=grants_aggregates.min_award_date %} awarded on <strong>{{start_date}}</strong>.{% endblocktrans %}{% else %}{% blocktrans with start_date=grants_aggregates.min_award_date end_date=grants_aggregates.max_award_date %}awarded between <strong>{{start_date}}</strong> and <strong>{{end_date}}</strong>.{% endblocktrans %}
                {% endif %}
               </li>
-              {% if metadata.description %}
+              {% if metadata.issued %}
                 <li>
                   The file was issued on <strong> {{metadata.issued|slice:":10"}} </strong>
                 </li>


### PR DESCRIPTION
'The file was issued on' should not be displayed if the cell in metadata tab is blank.
relates to https://github.com/OpenDataServices/cove/issues/1290

<img width="1135" alt="Screen Shot 2020-10-09 at 12 22 29" src="https://user-images.githubusercontent.com/9610927/95577967-fd545a00-0a2a-11eb-9668-e31b30ccb4c4.png">
