### PR TITLE
cove360: views: explore: metadata: lowercase dict keys.

### DIFF
--- a/cove_360/views.py
+++ b/cove_360/views.py
@@ -85,7 +85,13 @@ def explore_360(request, pk, template='cove_360/explore.html'):
 
     if hasattr(json_data, 'get') and hasattr(json_data.get('grants'), '__iter__'):
         context['grants'] = json_data['grants']
-        context['metadata'] = {key: value for key, value in json_data.items() if key != 'grants'}
+
+        context['metadata'] = {}
+        for key, value in json_data.items():
+            if key != 'grants':
+                if isinstance(value, dict):
+                    value = {k.lower(): v for k, v in value.items()}
+                context['metadata'][key.lower()] = value
     else:
         context['grants'] = []
         context['metadata'] = {}


### PR DESCRIPTION
Metadata keys were uppercase and not being displayed.
Relates to #1290

<img width="981" alt="Screen Shot 2020-10-15 at 14 29 47" src="https://user-images.githubusercontent.com/9610927/96263625-1de85b00-0fbb-11eb-8c8f-a50890e00486.png">
