### PR TITLE
Remove defusedexpat dependency, for compatibility with recent pythons

### DIFF
--- a/cove_iati/settings.py
+++ b/cove_iati/settings.py
@@ -1,12 +1,5 @@
-import sys
 import os
 import environ
-if "pytest" not in sys.modules:
-    # Check that we can import defusedexpat, as this will protect us against
-    # some XML attacks in xmltodict
-    # Needs a noqa comment as we don't actually use it here
-    import defusedexpat  # noqa: F401
-    pass
 
 # Needs a noqa comment to come after the above import
 from cove import settings  # noqa: E408

--- a/requirements_iati.txt
+++ b/requirements_iati.txt
@@ -12,4 +12,3 @@
 # We've not done this yet because this requires changes to cove, and some
 # careful testing, which we currently don't have time to do.
 -e git+https://github.com/OpenDataServices/bdd-tester.git@e1a1a578e28222904f3f1567409b068222ec02e6#egg=bdd-tester
--e git+https://github.com/OpenDataServices/defusedexpat@362a55a5f41ec2044e90ac54dc2fc52d5f979da3#egg=defusedexpat


### PR DESCRIPTION
This is still secure because xmltodict, the lib we depedend on that uses
pyexpat, ensures that entities don't get loaded by default.
https://github.com/martinblech/xmltodict/blob/ae19c452ca000bf243bfc16274c060bf3bf7cf51/xmltodict.py#L356-L366