### PR TITLE
Add "Transform" section, with merge indicators by title

### DIFF
--- a/cove_iati/templates/cove_iati/explore.html
+++ b/cove_iati/templates/cove_iati/explore.html
@@ -419,12 +419,13 @@
     <div id="transform-body" class="collapse {% if suffix %}in{% endif %}">
       <div class="panel-body">
         <p>
-          Merge indicators by title:
+          <h4>Merge indicators by title</h4>
+          <p>This function will merge together any indicators in the result block, that share the same title. No other data will be altered or changed. This function is designed for instances where multiple periods exist within the same result/indicator, but are not uniquely referenced in the IATI standard or CoVE spreadsheet.<p/>
           {% if merge_indicator_output %}
-          <a href="{{ merge_indicator_output }}">Output (xml)</a> {{ merge_indicator_output_file_size|filesizeformat }}.
-          <a target="_blank" href="http://d-preview.codeforiati.org/upload?xmlurl={{ request.scheme }}://{{ request.get_host }}{{ merge_indicator_output }}" class="btn btn-success btn-sm">Generate a d-preview</a>
+          <p><a href="{{ merge_indicator_output }}">Output (xml)</a> {{ merge_indicator_output_file_size|filesizeformat }}</p>
+          <p><a target="_blank" href="http://d-preview.codeforiati.org/upload?xmlurl={{ request.scheme }}://{{ request.get_host }}{{ merge_indicator_output }}" class="btn btn-success btn-sm">Generate a d-preview</a></p>
           {% else %}
-          <a href="{% url 'explore_suffix' data_uuid 'merge_indicator' %}" class="btn btn-success btn-sm">Run</a>
+          <p><a href="{% url 'explore_suffix' data_uuid 'merge_indicator' %}" class="btn btn-success btn-sm">Run</a></p>
           {% endif %}
         </p>
       </div>

--- a/cove_iati/templates/cove_iati/explore.html
+++ b/cove_iati/templates/cove_iati/explore.html
@@ -408,6 +408,30 @@
   </div>
   {% endblock download_and_share %}
 
+  {% block transforms %}
+  <div class="panel panel-default">
+    <div class="panel-heading panel-heading-explore" data-toggle="collapse" data-target="#transform-body">
+      <h3 class="panel-title panel-title-explore"><span class="glyphicon glyphicon-wrench"></span>
+        {% trans "Transform" %}
+        <span class="glyphicon glyphicon-collapse-down pull-right"></span>
+      </h3>
+    </div>
+    <div id="transform-body" class="collapse {% if suffix %}in{% endif %}">
+      <div class="panel-body">
+        <p>
+          Merge indicators by title:
+          {% if merge_indicator_output %}
+          <a href="{{ merge_indicator_output }}">Output (xml)</a> {{ merge_indicator_output_file_size|filesizeformat }}.
+          <a target="_blank" href="http://d-preview.codeforiati.org/upload?xmlurl={{ request.scheme }}://{{ request.get_host }}{{ merge_indicator_output }}" class="btn btn-success btn-sm">Generate a d-preview</a>
+          {% else %}
+          <a href="{% url 'explore_suffix' data_uuid 'merge_indicator' %}" class="btn btn-success btn-sm">Run</a>
+          {% endif %}
+        </p>
+      </div>
+    </div>
+  </div>
+  {% endblock %}
+
 {% endblock explore_content %}
 
 {% block extrafooterscript %}

--- a/cove_iati/urls.py
+++ b/cove_iati/urls.py
@@ -8,6 +8,7 @@ import cove_iati.views
 
 urlpatterns = [
     url(r'^$', cove_iati.views.data_input_iati, name='index'),
+    url(r'^data/(.+)/(.+)$', cove_iati.views.explore_iati, name='explore_suffix'),
     url(r'^data/(.+)$', cove_iati.views.explore_iati, name='explore'),
     url(r'^api_test', cove_iati.views.api_test, name='api_test'),
 ] + urlpatterns

--- a/requirements_iati.txt
+++ b/requirements_iati.txt
@@ -12,3 +12,4 @@
 # We've not done this yet because this requires changes to cove, and some
 # careful testing, which we currently don't have time to do.
 -e git+https://github.com/OpenDataServices/bdd-tester.git@e1a1a578e28222904f3f1567409b068222ec02e6#egg=bdd-tester
+-e git+https://github.com/OpenDataServices/iati-utils.git@704fa589ad2d3743d3928dcbeeeb06a5e73f8437#egg=iatiutils


### PR DESCRIPTION
There's now a dev deploy of this at http://merge-indicator.dev.cove.opendataservices.coop/data/f8074830-45f1-4caa-a3b6-ebb4a2c21d30

I've added a "Transform" block that's collapsed by default:

![Screenshot from 2022-05-18 14-05-11](https://user-images.githubusercontent.com/634/169045682-1132bec0-9dce-4398-89d0-6aae99c7b60a.png)

This is what it looks like expanded:

![Screenshot from 2022-05-18 14-05-22](https://user-images.githubusercontent.com/634/169045722-3b12cf85-fc1f-4e7e-977b-5411d6ffb7b6.png)

After hitting the Run button:

![Screenshot from 2022-05-18 14-20-19](https://user-images.githubusercontent.com/634/169048390-bd89b7fc-c312-4701-936b-d27cfbb17efa.png)

This is all on one line, with a view to adding extra Transforms in the future.

@stevieflow How does this look? Are you happy with this Transform block being visible to all users? If you want we can write some text to go into the block to explain what it is.
