### PR TITLE
requirements: Pin old openpyxl version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ CommonMark
 bleach
 xmltodict
 rangedict
-openpyxl
+openpyxl==3.1.2
 gunicorn
 lxml<5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ markupsafe==2.1.5
     # via werkzeug
 odfpy==1.4.1
     # via flattentool
-openpyxl==3.1.5
+openpyxl==3.1.2
     # via
     #   -r requirements.in
     #   flattentool

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -180,7 +180,7 @@ odfpy==1.4.1
     #   flattentool
 odsc-default-sphinx-theme==0.0.1
     # via -r requirements_dev.in
-openpyxl==3.1.5
+openpyxl==3.1.2
     # via
     #   -r requirements.txt
     #   flattentool


### PR DESCRIPTION
This avoids particular spreadsheets breaking:
https://github.com/OpenDataServices/flatten-tool/issues/466

I've just done this in IATI CoVE for now, as that's the only place we've seen it. We can look into whether it makes sense to do this in flatten-tool, although I think there's downsides to that.